### PR TITLE
fix: disable legacy Slack job notifier

### DIFF
--- a/.github/workflows/import-jobs.yml
+++ b/.github/workflows/import-jobs.yml
@@ -39,8 +39,6 @@ jobs:
           git pull --rebase origin main
           git push
 
-      - name: Notify Slack of new jobs
-        if: success()
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        run: node scripts/notify-slack.js
+      # Slack job digests are now handled by the Hermes gateway cron job.
+      # Keeping notification logic out of this workflow prevents duplicate posts
+      # from the legacy ET's Bot webhook.


### PR DESCRIPTION
Hermes/HK-47 now owns the Slack job digest via the gateway cron job posting to #talk_jobs. This removes the legacy GitHub Actions Slack webhook notifier to prevent duplicate job posts from ETs Bot.\n\nThe import job still runs and commits job refreshes as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized notification delivery by removing duplicate Slack notification steps, ensuring streamlined job digest distribution through dedicated notification systems.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GRCEngClub/directory/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->