### PR TITLE
chore(deps): patch linkify-it vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1013,9 +1013,9 @@
       }
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- remediates Dependabot alert #21 / CVE-2026-59887 (`GHSA-v245-v573-v5vm`)
- updates transitive development dependency `linkify-it` from 5.0.1 to 5.0.2
- keeps the change scoped to `package-lock.json`

## Dependency path
`@11ty/eleventy@3.1.2` → `markdown-it@14.2.0` → `linkify-it`

## Risk
The advisory is a high-severity availability issue (CVSS 7.5, CWE-407): quadratic-complexity denial of service in the `mailto:` linkifier. Exposure is limited because this dependency is used during static-site builds, not served as runtime application code, but repository-controlled Markdown is processed during builds.

## Verification
- `npm ci --no-audit --no-fund`
- `npm audit --audit-level=low` → 0 vulnerabilities
- `npm ls linkify-it --all` → 5.0.2
- `npm run build` → 196 files generated successfully
- `git diff --check`

Resolves Dependabot alert #21.