### PR TITLE
feat: import GRC jobs from a16z Speedrun

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "awesome-grc-engineer-directory",
       "version": "1.0.0",
       "devDependencies": {
-        "@11ty/eleventy": "^3.0.0"
+        "@11ty/eleventy": "^3.0.0",
+        "nunjucks": "^3.2.4"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -1239,6 +1240,7 @@
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
       "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "import:jobs": "node scripts/import-jobs.js"
   },
   "devDependencies": {
-    "@11ty/eleventy": "^3.0.0"
+    "@11ty/eleventy": "^3.0.0",
+    "nunjucks": "^3.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "eleventy",
     "serve": "eleventy --serve",
+    "test": "node --test tests/*.test.js",
     "import:jobs": "node scripts/import-jobs.js"
   },
   "devDependencies": {

--- a/scripts/import-jobs.js
+++ b/scripts/import-jobs.js
@@ -160,6 +160,9 @@ function htmlToMarkdown(value) {
     .replace(/&amp;/g, "&")
     .replace(/&quot;/g, "\"")
     .replace(/&#39;/g, "'")
+    // Entity decoding above can reintroduce active HTML; keep Markdown text-only.
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
     .replace(/\r/g, "")
     .replace(/[ \t]+\n/g, "\n")
     .replace(/\n{3,}/g, "\n\n");
@@ -373,8 +376,18 @@ function titleMayBeRelevant(title) {
   return includesAny(t, signals);
 }
 
+// Imported descriptions are untrusted. Eleventy evaluates Nunjucks syntax in
+// Markdown files, so neutralize opening delimiters before writing any field.
+function escapeTemplateSyntax(value) {
+  return String(value || "")
+    .replace(/</g, "&lt;")
+    .replace(/\{\{/g, "&#123;&#123;")
+    .replace(/\{%/g, "&#123;%")
+    .replace(/\{#/g, "&#123;#");
+}
+
 function yamlString(value) {
-  return JSON.stringify(String(value || ""));
+  return JSON.stringify(escapeTemplateSyntax(value));
 }
 
 function yamlList(key, values) {
@@ -441,7 +454,7 @@ function serializeJob(job) {
     "summary: " + yamlString(job.summary || ""),
     "---",
     "",
-    job.body || "No description was provided by the upstream source."
+    escapeTemplateSyntax(job.body || "No description was provided by the upstream source.")
   ];
 
   return frontmatter.join("\n") + "\n";
@@ -580,6 +593,236 @@ function normalizeAshbyJob(boardName, job) {
     summary,
     body: description
   });
+}
+
+function safeHttpUrl(value) {
+  const raw = String(value || "").trim();
+  if (!raw) return "";
+
+  try {
+    const url = new URL(raw);
+    return ["http:", "https:"].includes(url.protocol) ? url.toString() : "";
+  } catch (_error) {
+    return "";
+  }
+}
+
+function canonicalizeApplyUrl(value) {
+  const raw = safeHttpUrl(value);
+  if (!raw) return "";
+
+  try {
+    const url = new URL(raw);
+    const trackingParameters = /^(?:utm_.+|ref|referrer|source|src|gh_src|lever-source|tracking|trk)$/i;
+    [...url.searchParams.keys()].forEach(function(key) {
+      if (trackingParameters.test(key)) url.searchParams.delete(key);
+    });
+    url.searchParams.sort();
+    url.hash = "";
+    url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+    return url.toString().replace(/\/$/, "");
+  } catch (_error) {
+    return "";
+  }
+}
+
+function extractApplyUrlFromJobFile(content) {
+  const match = String(content || "").match(/^apply_url:\s*(.+)$/m);
+  if (!match) return "";
+
+  let value = match[1].trim();
+  try {
+    value = JSON.parse(value);
+  } catch (_error) {
+    value = value.replace(/^['"]|['"]$/g, "");
+  }
+  return canonicalizeApplyUrl(value);
+}
+
+function mergeSpeedrunCandidates(payloads) {
+  const candidates = [];
+  const seen = new Set();
+
+  (payloads || []).forEach(function(payload) {
+    const jobs = payload && Array.isArray(payload.jobs) ? payload.jobs : [];
+    jobs.forEach(function(job) {
+      const id = String(job && job.id || "");
+      if (!id || seen.has(id) || !titleMayBeRelevant(job.title)) return;
+      seen.add(id);
+      candidates.push(job);
+    });
+  });
+
+  return candidates;
+}
+
+function speedrunLooksRelevant(title, text) {
+  const titleText = String(title || "").toLowerCase();
+  const fullText = String(text || "").toLowerCase();
+  const nonGrcTitleTerms = [
+    "cost accounting", "blockchain compliance", "import compliance",
+    "export compliance", "trade compliance", "marine compliance",
+    "aviation compliance", "product compliance", "quality compliance",
+    "tax compliance", "environmental compliance", "safety compliance",
+    "regulatory affairs", "kyc", "aml", "anti-money laundering"
+  ];
+  if (includesAny(titleText, nonGrcTitleTerms)) return false;
+  if (!looksRelevant(title, text)) return false;
+
+  const technicalTitleSignals = [
+    "grc", "security compliance", "security & compliance",
+    "security and compliance", "security governance", "technology risk",
+    "cyber risk", "privacy engineering", "privacy compliance",
+    "controls assurance", "security assurance", "third-party risk",
+    "vendor risk", "risk and compliance", "risk & compliance",
+    "it compliance", "compliance automation", "fedramp", "cmmc"
+  ];
+  const technicalContentPhrases = [
+    "governance, risk", "governance risk",
+    "information security", "cybersecurity", "security program",
+    "security compliance", "security controls", "third-party risk",
+    "vendor risk", "customer trust", "trust center", "audit evidence",
+    "evidence collection", "identity and access", "identity & access"
+  ];
+  const frameworkOrToolSignal = /\b(?:grc|nist|fedramp|cmmc|hipaa|gdpr|drata|vanta)\b|\bsoc\s*2\b|\biso\s*27001\b|\bpci(?:\s|-)?dss\b/i;
+
+  return includesAny(titleText, technicalTitleSignals)
+    || includesAny(fullText, technicalContentPhrases)
+    || frameworkOrToolSignal.test(fullText);
+}
+
+function normalizeSpeedrunJob(listing, detail) {
+  const data = detail || {};
+  if (data.status && data.status !== "open") return null;
+
+  const title = data.title || listing.title;
+  const company = data.company || listing.company || "Unknown company";
+  const location = data.location || listing.location || "Remote";
+  const rawDescription = data.description_text || "";
+  const body = htmlToMarkdown(rawDescription);
+  const text = [title, company, location, body].join(" ");
+  if (!speedrunLooksRelevant(title, text)) return null;
+
+  const id = String(data.id || listing.id || "");
+  const postedDate = toIsoDate(data.published_at || listing.published_at || Date.now());
+  const roleUrl = safeHttpUrl(listing.url)
+    || safeHttpUrl(data.url)
+    || safeHttpUrl(data.apply && data.apply.url);
+  if (!roleUrl) return null;
+  const slug = slugify(["speedrun", company, id.slice(0, 8), title].join("-")).slice(0, 120);
+  if (!slug) return null;
+
+  return buildNormalizedJob({
+    title,
+    company,
+    slug,
+    source: "a16z Speedrun",
+    sources: ["a16z Speedrun"],
+    source_url: "https://speedrun-talent-network.com/api/v1/jobs",
+    role_url: roleUrl,
+    apply_url: roleUrl,
+    posted_date: postedDate,
+    expires_date: addDays(postedDate, 30),
+    location,
+    work_modes: (data.remote || listing.remote || /remote/i.test(String(data.workplace_type || listing.workplace_type || "")))
+      ? ["Remote"]
+      : ["Hybrid / On-site"],
+    job_types: [normalizeJobType(data.employment_type || listing.employment_type)],
+    compensation: data.comp_summary || formatCompensation(data.comp_min, data.comp_max, data.comp_currency || "USD"),
+    summary: rawDescription,
+    body
+  });
+}
+
+const SPEEDRUN_API_BASE = "https://speedrun-talent-network.com/api/v1";
+const SPEEDRUN_SEARCH_TERMS = [
+  "compliance",
+  "grc",
+  "security governance",
+  "technology risk",
+  "third-party risk",
+  "vendor risk",
+  "security assurance",
+  "privacy engineering",
+  "fedramp",
+  "cmmc",
+  "controls assurance"
+];
+
+async function collectSpeedrunJobs(fetcher, options) {
+  const settings = options || {};
+  const searchTerms = settings.searchTerms || SPEEDRUN_SEARCH_TERMS;
+  const pagesPerTerm = settings.pagesPerTerm || 2;
+  const existingApplyUrls = settings.existingApplyUrls || new Set();
+  const seenApplyUrls = new Set(existingApplyUrls);
+  const searchRequests = [];
+  searchTerms.forEach(function(term) {
+    for (let page = 0; page < pagesPerTerm; page++) {
+      const url = new URL(SPEEDRUN_API_BASE + "/jobs");
+      url.searchParams.set("q", term);
+      url.searchParams.set("sort", "rel");
+      url.searchParams.set("page", String(page));
+      url.searchParams.set("source", "grcengclub");
+      searchRequests.push(url.toString());
+    }
+  });
+  const payloads = await Promise.all(searchRequests.map(function(url) {
+    return fetcher(url);
+  }));
+  const candidates = mergeSpeedrunCandidates(payloads);
+  const imported = [];
+  const batchSize = 8;
+
+  for (let i = 0; i < candidates.length; i += batchSize) {
+    const batch = candidates.slice(i, i + batchSize);
+    const details = await Promise.all(batch.map(function(listing) {
+      const detailUrl = SPEEDRUN_API_BASE + "/jobs/" + encodeURIComponent(listing.id) + "?source=grcengclub";
+      return fetcher(detailUrl).catch(function(error) {
+        console.warn("[speedrun] failed to fetch detail for " + listing.id + ": " + error.message);
+        return null;
+      });
+    }));
+
+    details.forEach(function(payload, index) {
+      if (!payload || !payload.job) return;
+      const detail = payload.job;
+      const upstreamApplyUrl = canonicalizeApplyUrl(detail.apply && detail.apply.url);
+      if (upstreamApplyUrl && seenApplyUrls.has(upstreamApplyUrl)) return;
+      const normalized = normalizeSpeedrunJob(batch[index], detail);
+      if (normalized) {
+        imported.push(normalized);
+        if (upstreamApplyUrl) seenApplyUrls.add(upstreamApplyUrl);
+      }
+    });
+  }
+
+  return imported;
+}
+
+async function importSpeedrun() {
+  const existingApplyUrls = new Set();
+  let entries = [];
+  try {
+    entries = await fs.readdir(IMPORT_ROOT, { recursive: true });
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+
+  const files = entries.filter(function(entry) {
+    const normalized = String(entry).replace(/\\/g, "/");
+    return normalized.endsWith(".md") && !normalized.startsWith("speedrun/");
+  });
+  const contents = await Promise.all(files.map(function(entry) {
+    return fs.readFile(path.join(IMPORT_ROOT, entry), "utf8");
+  }));
+  contents.forEach(function(content) {
+    const applyUrl = extractApplyUrlFromJobFile(content);
+    if (applyUrl) existingApplyUrls.add(applyUrl);
+  });
+
+  const jobs = await collectSpeedrunJobs(fetchJson, { existingApplyUrls });
+  console.log("[speedrun] filtered against " + existingApplyUrls.size + " existing apply URLs");
+  return jobs;
 }
 
 async function importRemoteOk() {
@@ -890,10 +1133,11 @@ async function main() {
   total += await runSource("workable", configuredBoards("WORKABLE_BOARDS", catalogWorkableBoards).length > 0, importWorkable);
   total += await runSource("lever", configuredBoards("LEVER_BOARDS", catalogLeverBoards).length > 0, importLever);
   total += await runSource("rippling", configuredBoards("RIPPLING_BOARDS", catalogRipplingBoards).length > 0, importRippling);
+  total += await runSource("speedrun", envFlag("SPEEDRUN_ENABLED", true), importSpeedrun);
 
   if (total === 0) {
     console.log("No jobs matched the current GRC filters.");
-    console.log("Tip: curated Greenhouse, Ashby, Workable, Lever, and Rippling boards are checked into the repo.");
+    console.log("Tip: curated ATS boards and the a16z Speedrun API are checked automatically.");
   }
 }
 
@@ -905,7 +1149,14 @@ if (require.main === module) {
 }
 
 module.exports = {
+  canonicalizeApplyUrl,
+  collectSpeedrunJobs,
+  extractApplyUrlFromJobFile,
   extractCompensation,
   htmlToMarkdown,
-  looksRelevant
+  importSpeedrun,
+  looksRelevant,
+  mergeSpeedrunCandidates,
+  normalizeSpeedrunJob,
+  serializeJob
 };

--- a/scripts/import-jobs.js
+++ b/scripts/import-jobs.js
@@ -627,7 +627,10 @@ function canonicalizeApplyUrl(value) {
 }
 
 function extractApplyUrlFromJobFile(content) {
-  const match = String(content || "").match(/^apply_url:\s*(.+)$/m);
+  const frontmatter = String(content || "").match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  if (!frontmatter) return "";
+
+  const match = frontmatter[1].match(/^apply_url:\s*(.+)$/m);
   if (!match) return "";
 
   let value = match[1].trim();
@@ -766,9 +769,15 @@ async function collectSpeedrunJobs(fetcher, options) {
       searchRequests.push(url.toString());
     }
   });
-  const payloads = await Promise.all(searchRequests.map(function(url) {
-    return fetcher(url);
-  }));
+  const payloads = (await Promise.all(searchRequests.map(function(url) {
+    return fetcher(url).catch(function(error) {
+      console.warn("[speedrun] failed search " + url + ": " + error.message);
+      return null;
+    });
+  }))).filter(Boolean);
+  if (searchRequests.length && payloads.length === 0) {
+    throw new Error("All Speedrun search requests failed");
+  }
   const candidates = mergeSpeedrunCandidates(payloads);
   const imported = [];
   const batchSize = 8;

--- a/tests/import-speedrun-jobs.test.js
+++ b/tests/import-speedrun-jobs.test.js
@@ -183,6 +183,36 @@ test("collectSpeedrunJobs fetches attributed searches and job details", async ()
   assert.match(requests[1], /\/api\/v1\/jobs\/job-1\?source=grcengclub/);
 });
 
+test("collectSpeedrunJobs continues when one search page fails", async () => {
+  const listing = {
+    id: "job-partial",
+    title: "Security Compliance Engineer",
+    company: "Example",
+    location: "Remote",
+    remote: true,
+    url: "https://speedrun-talent-network.com/jobs/job-partial?utm_source=grcengclub"
+  };
+  const fetcher = async (url) => {
+    if (url.includes("q=broken")) throw new Error("temporary upstream failure");
+    if (url.includes("/jobs?")) return { jobs: [listing] };
+    return {
+      job: {
+        ...listing,
+        status: "open",
+        apply: { url: "https://example.com/apply?job=partial" },
+        description_text: "Security compliance automation, SOC 2 controls, and audit evidence."
+      }
+    };
+  };
+
+  const jobs = await collectSpeedrunJobs(fetcher, {
+    searchTerms: ["broken", "security compliance"],
+    pagesPerTerm: 1
+  });
+
+  assert.equal(jobs.length, 1);
+});
+
 test("collectSpeedrunJobs requests each configured search page", async () => {
   const requests = [];
   const fetcher = async (url) => {
@@ -276,6 +306,15 @@ test("extractApplyUrlFromJobFile reads generated frontmatter safely", () => {
     extractApplyUrlFromJobFile(markdown),
     "https://example.com/apply/job-1"
   );
+
+  const poisonedBodyOnly = [
+    "---",
+    "title: \"Security Compliance Engineer\"",
+    "---",
+    "Description",
+    "apply_url: \"https://example.com/poison\""
+  ].join("\n");
+  assert.equal(extractApplyUrlFromJobFile(poisonedBodyOnly), "");
 });
 
 test("htmlToMarkdown neutralizes encoded HTML that could become active markup", () => {
@@ -308,7 +347,7 @@ test("serializeJob neutralizes Nunjucks syntax from untrusted job data", () => {
     languages: [],
     compensation: "",
     summary: "{{ 7 * 7 }}",
-    body: "{% include \"package.json\" %}\n{# untrusted comment #}"
+    body: "{% include \"package.json\" %}\n{# untrusted comment #}\n{{{\n{{#\n{#{"
   };
 
   const markdown = serializeJob(job);

--- a/tests/import-speedrun-jobs.test.js
+++ b/tests/import-speedrun-jobs.test.js
@@ -1,0 +1,330 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const nunjucks = require("nunjucks");
+
+const {
+  canonicalizeApplyUrl,
+  collectSpeedrunJobs,
+  extractApplyUrlFromJobFile,
+  htmlToMarkdown,
+  mergeSpeedrunCandidates,
+  normalizeSpeedrunJob,
+  serializeJob
+} = require("../scripts/import-jobs");
+
+test("normalizeSpeedrunJob creates an attributed GRC job", () => {
+  const listing = {
+    id: "81fcada5-9746-4074-bf94-d39c25bbc07a",
+    title: "Security & Compliance Operations Manager",
+    company: "Mintlify",
+    location: "San Francisco",
+    employment_type: "FullTime",
+    remote: false,
+    workplace_type: "OnSite",
+    published_at: "2026-07-13T16:58:15.302+00:00",
+    url: "https://speedrun-talent-network.com/jobs/security-compliance-operations-manager-mintlify-81fcada5?utm_source=grcengclub&utm_medium=agent"
+  };
+  const detail = {
+    status: "open",
+    title: listing.title,
+    company: listing.company,
+    location: listing.location,
+    employment_type: listing.employment_type,
+    remote: listing.remote,
+    workplace_type: listing.workplace_type,
+    published_at: listing.published_at,
+    comp_summary: "$120K – $180K",
+    apply: {
+      kind: "external",
+      url: "https://jobs.ashbyhq.com/Mintlify/81fcada5-9746-4074-bf94-d39c25bbc07a/application"
+    },
+    description_text: "Own the GRC program, SOC 2 Type II, ISO 27001, evidence collection, and compliance automation."
+  };
+
+  const job = normalizeSpeedrunJob(listing, detail);
+
+  assert.equal(job.source, "a16z Speedrun");
+  assert.equal(job.apply_url, listing.url);
+  assert.equal(job.role_url, listing.url);
+  assert.equal(job.compensation, "$120K – $180K");
+  assert.deepEqual(job.work_modes, ["Hybrid / On-site"]);
+  assert.deepEqual(job.job_types, ["Full-time"]);
+  assert.ok(job.frameworks.includes("SOC 2"));
+  assert.ok(job.frameworks.includes("ISO 27001"));
+  assert.ok(job.specializations.includes("Compliance Automation"));
+  assert.match(job.slug, /^speedrun-mintlify-81fcada5/);
+});
+
+test("normalizeSpeedrunJob rejects non-HTTP application URLs", () => {
+  const listing = {
+    id: "unsafe-1",
+    title: "Security Compliance Engineer",
+    company: "Example",
+    url: "javascript:alert(document.domain)"
+  };
+  const detail = {
+    status: "open",
+    title: listing.title,
+    company: listing.company,
+    apply: { url: "javascript:alert(document.domain)" },
+    description_text: "Security compliance, SOC 2, audit evidence, and control automation."
+  };
+
+  assert.equal(normalizeSpeedrunJob(listing, detail), null);
+});
+
+test("normalizeSpeedrunJob rejects non-GRC compliance roles", () => {
+  const listing = {
+    id: "job-2",
+    title: "Cost Accounting Compliance Analyst",
+    company: "Defense Co",
+    location: "California",
+    url: "https://speedrun-talent-network.com/jobs/cost-accounting-compliance-analyst-job-2?utm_source=grcengclub&utm_medium=agent"
+  };
+  const detail = {
+    status: "open",
+    title: listing.title,
+    company: listing.company,
+    description_text: "Maintain accounting policies, audit cost submissions, assess financial risk, and ensure contract compliance."
+  };
+
+  assert.equal(normalizeSpeedrunJob(listing, detail), null);
+});
+
+test("normalizeSpeedrunJob does not match framework names inside ordinary words", () => {
+  const listing = {
+    id: "job-3",
+    title: "Compliance Analyst",
+    company: "Finance Co",
+    location: "New York",
+    url: "https://speedrun-talent-network.com/jobs/compliance-analyst-job-3?utm_source=grcengclub&utm_medium=agent"
+  };
+  const detail = {
+    status: "open",
+    title: listing.title,
+    company: listing.company,
+    description_text: "Administer financial policies and maintain advantageous banking controls."
+  };
+
+  assert.equal(normalizeSpeedrunJob(listing, detail), null);
+});
+
+test("mergeSpeedrunCandidates keeps relevant unique listings", () => {
+  const compliance = {
+    id: "job-1",
+    title: "Security Compliance Engineer",
+    company: "Example"
+  };
+  const payloads = [
+    { jobs: [compliance, { id: "job-2", title: "Head of Marketing", company: "Example" }] },
+    { jobs: [compliance, { id: "job-3", title: "Technology Risk Analyst", company: "Example" }] }
+  ];
+
+  const candidates = mergeSpeedrunCandidates(payloads);
+
+  assert.deepEqual(candidates.map((job) => job.id), ["job-1", "job-3"]);
+});
+
+test("canonicalizeApplyUrl removes tracking without changing the application path", () => {
+  const url = "https://Jobs.AshbyHQ.com/Mintlify/job-1/application/?utm_source=test#apply";
+
+  assert.equal(
+    canonicalizeApplyUrl(url),
+    "https://jobs.ashbyhq.com/Mintlify/job-1/application"
+  );
+  assert.equal(
+    canonicalizeApplyUrl("https://example.com/apply?job=123&utm_source=board"),
+    "https://example.com/apply?job=123"
+  );
+  assert.notEqual(
+    canonicalizeApplyUrl("https://example.com/apply?job=123"),
+    canonicalizeApplyUrl("https://example.com/apply?job=456")
+  );
+});
+
+test("collectSpeedrunJobs fetches attributed searches and job details", async () => {
+  const listing = {
+    id: "job-1",
+    title: "Security Compliance Engineer",
+    company: "Example",
+    location: "Remote",
+    remote: true,
+    employment_type: "FullTime",
+    published_at: "2026-07-30T00:00:00Z",
+    url: "https://speedrun-talent-network.com/jobs/security-compliance-engineer-example-job-1?utm_source=grcengclub&utm_medium=agent"
+  };
+  const detail = {
+    id: "job-1",
+    status: "open",
+    title: listing.title,
+    company: listing.company,
+    location: listing.location,
+    remote: true,
+    employment_type: listing.employment_type,
+    published_at: listing.published_at,
+    apply: { url: "https://example.com/apply/job-1" },
+    description_text: "Build security compliance automation for SOC 2 evidence and controls."
+  };
+  const requests = [];
+  const fetcher = async (url) => {
+    requests.push(url);
+    return url.includes("/jobs?") ? { jobs: [listing] } : { job: detail };
+  };
+
+  const jobs = await collectSpeedrunJobs(fetcher, {
+    searchTerms: ["security compliance"],
+    pagesPerTerm: 1,
+    existingApplyUrls: new Set()
+  });
+
+  assert.equal(jobs.length, 1);
+  assert.match(requests[0], /q=security\+compliance/);
+  assert.match(requests[0], /source=grcengclub/);
+  assert.match(requests[1], /\/api\/v1\/jobs\/job-1\?source=grcengclub/);
+});
+
+test("collectSpeedrunJobs requests each configured search page", async () => {
+  const requests = [];
+  const fetcher = async (url) => {
+    requests.push(url);
+    return { jobs: [] };
+  };
+
+  await collectSpeedrunJobs(fetcher, {
+    searchTerms: ["grc"],
+    pagesPerTerm: 2
+  });
+
+  assert.equal(requests.length, 2);
+  assert.match(requests[0], /page=0/);
+  assert.match(requests[1], /page=1/);
+});
+
+test("collectSpeedrunJobs skips roles already imported from another board", async () => {
+  const listing = {
+    id: "job-1",
+    title: "Security Compliance Engineer",
+    company: "Example",
+    location: "Remote",
+    remote: true,
+    url: "https://speedrun-talent-network.com/jobs/security-compliance-engineer-example-job-1?utm_source=grcengclub&utm_medium=agent"
+  };
+  const detail = {
+    id: listing.id,
+    status: "open",
+    title: listing.title,
+    company: listing.company,
+    location: listing.location,
+    remote: true,
+    apply: { url: "https://example.com/apply/job-1?ref=speedrun" },
+    description_text: "Security compliance automation, controls, SOC 2, and audit evidence."
+  };
+  const fetcher = async (url) => url.includes("/jobs?") ? { jobs: [listing] } : { job: detail };
+
+  const jobs = await collectSpeedrunJobs(fetcher, {
+    searchTerms: ["security compliance"],
+    existingApplyUrls: new Set(["https://example.com/apply/job-1"])
+  });
+
+  assert.deepEqual(jobs, []);
+});
+
+test("collectSpeedrunJobs deduplicates repeated upstream application URLs in one run", async () => {
+  const listings = ["job-1", "job-2"].map((id) => ({
+    id,
+    title: "Security Compliance Engineer",
+    company: "Example",
+    location: "Remote",
+    remote: true,
+    url: `https://speedrun-talent-network.com/jobs/${id}?utm_source=grcengclub`
+  }));
+  const fetcher = async (url) => {
+    if (url.includes("/jobs?")) return { jobs: listings };
+    const id = url.includes("job-1") ? "job-1" : "job-2";
+    return {
+      job: {
+        id,
+        status: "open",
+        title: listings[0].title,
+        company: listings[0].company,
+        location: "Remote",
+        remote: true,
+        apply: { url: "https://example.com/apply?job=123&utm_source=speedrun" },
+        description_text: "Security compliance automation, SOC 2 controls, and audit evidence."
+      }
+    };
+  };
+
+  const jobs = await collectSpeedrunJobs(fetcher, {
+    searchTerms: ["security compliance"],
+    pagesPerTerm: 1
+  });
+
+  assert.equal(jobs.length, 1);
+});
+
+test("extractApplyUrlFromJobFile reads generated frontmatter safely", () => {
+  const markdown = [
+    "---",
+    "title: \"Security Compliance Engineer\"",
+    "apply_url: \"https://example.com/apply/job-1?utm_source=board\"",
+    "---",
+    "Description"
+  ].join("\n");
+
+  assert.equal(
+    extractApplyUrlFromJobFile(markdown),
+    "https://example.com/apply/job-1"
+  );
+});
+
+test("htmlToMarkdown neutralizes encoded HTML that could become active markup", () => {
+  const markdown = htmlToMarkdown(
+    "Security role &lt;img src=x onerror=alert(1)&gt; &lt;script&gt;alert(2)&lt;/script&gt;"
+  );
+
+  assert.doesNotMatch(markdown, /<img|<script/i);
+  assert.match(markdown, /&lt;img/);
+  assert.match(markdown, /&lt;script/);
+});
+
+test("serializeJob neutralizes Nunjucks syntax from untrusted job data", () => {
+  const job = {
+    title: "Security {{ 7 * 7 }} Engineer </script><script>alert(1)</script>",
+    company: "{% include \"package.json\" %}",
+    slug: "security-engineer",
+    source: "a16z Speedrun",
+    sources: ["a16z Speedrun"],
+    source_url: "https://speedrun-talent-network.com/api/v1/jobs",
+    role_url: "https://speedrun-talent-network.com/jobs/job-1",
+    apply_url: "https://speedrun-talent-network.com/jobs/job-1",
+    posted_date: "2026-07-30",
+    expires_date: "2026-08-29",
+    location: "Remote",
+    work_modes: ["Remote"],
+    job_types: ["Full-time"],
+    specializations: ["Security Governance"],
+    frameworks: [],
+    languages: [],
+    compensation: "",
+    summary: "{{ 7 * 7 }}",
+    body: "{% include \"package.json\" %}\n{# untrusted comment #}"
+  };
+
+  const markdown = serializeJob(job);
+
+  assert.doesNotMatch(markdown, /\{\{|\{%|\{#/);
+  assert.doesNotMatch(markdown, /<\/script/i);
+  assert.match(markdown, /&#123;&#123; 7 \* 7 }}/);
+  assert.match(markdown, /&lt;\/script>/i);
+  assert.match(markdown, /&#123;% include/);
+  assert.match(markdown, /&#123;# untrusted comment/);
+
+  const serializedTitle = markdown.match(/^title: (.+)$/m)[1];
+  const renderedJsonLd = nunjucks.renderString(
+    "<script>{{ title | dump | safe }}</script>",
+    { title: JSON.parse(serializedTitle) }
+  );
+  assert.equal((renderedJsonLd.match(/<\/script>/gi) || []).length, 1);
+  assert.doesNotMatch(renderedJsonLd, /<\/script><script>/i);
+});


### PR DESCRIPTION
## Summary
- add a read-only a16z Speedrun Talent Network source to the existing daily jobs importer
- query targeted GRC/security terms with `source=grcengclub`, fetch details, normalize records, and preserve attributed Speedrun application links
- deduplicate against existing ATS listings and repeated Speedrun application URLs while preserving identity-bearing URL parameters
- filter out non-GRC compliance roles and keep the existing digest pipeline unchanged
- harden all imported job serialization against Nunjucks injection, JSON-LD script breakout, unsafe URL schemes, and encoded-HTML activation

## Verification
- `npm test` — 13/13 passing
- `npm run build` — passing
- live `npm run import:jobs` — Speedrun source wrote 42 jobs
- direct malicious Nunjucks/JSON-LD rendering regression — passing
- independent final review — approved with no security or logic findings

## Privacy / scope
- uses only the documented public REST jobs API
- sends no candidate data
- does not enable or invoke MCP write actions such as `join_network` or `express_interest`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “a16z Speedrun” job source with pagination, duplicate detection, and relevance filtering.
  * Job listings now include normalized application links and consistent metadata.
* **Bug Fixes**
  * Improved protection against unsafe HTML and template syntax in imported job content.
  * Removed tracking parameters and anchors from application URLs.
* **Tests**
  * Added comprehensive coverage for importing, normalization, deduplication, URL handling, and content safety.
* **Chores**
  * Added a standard command for running the automated test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->