### PR TITLE
fix: run job import before morning digest

### DIFF
--- a/.github/workflows/import-jobs.yml
+++ b/.github/workflows/import-jobs.yml
@@ -2,8 +2,8 @@ name: Import Jobs
 
 on:
   schedule:
-    # Daily at 11:17 UTC. The explicit day range preserves the existing cadence.
-    - cron: '17 11 * * 0-6'
+    # Daily at 09:17 UTC, leaving a buffer before the 12:00 UTC Slack digest.
+    - cron: '17 9 * * 0-6'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- move the daily job import from 11:17 UTC to 09:17 UTC
- leave a 2 hour 43 minute buffer before the 12:00 UTC Slack job digest
- avoid recent GitHub Actions schedule delays causing fresh imports to miss the same-day digest

## Verification
- workflow YAML parsed successfully
- schedule assertion passed
- `npm test` — 14/14 passing
- `npm run build` — passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the daily import-jobs workflow to run at 09:17 UTC instead of 11:17 UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->