### PR TITLE
feat: add Chapter Leads section to the directory

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -55,6 +55,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.ignores.add("engineers/_template.md");
   eleventyConfig.ignores.add("jobs/_template.md");
   eleventyConfig.ignores.add("jobs/**/_template.md");
+  eleventyConfig.ignores.add("chapters/_template.md");
 
   eleventyConfig.addCollection("engineers", function (api) {
     return api
@@ -75,6 +76,19 @@ module.exports = function (eleventyConfig) {
       .filter((item) => !String(item.page.fileSlug || "").startsWith("_"))
       .filter((item) => isLiveJob(item.data))
       .sort(sortByRecent);
+  });
+
+  eleventyConfig.addCollection("chapters", function (api) {
+    return api
+      .getFilteredByGlob("chapters/*.md")
+      .filter((item) => item.page.fileSlug !== "_template")
+      .sort((a, b) => {
+        const statusRank = { official: 0, provisional: 1, open: 2 };
+        const aRank = statusRank[String(a.data.status || "").toLowerCase()] ?? 9;
+        const bRank = statusRank[String(b.data.status || "").toLowerCase()] ?? 9;
+        if (aRank !== bRank) return aRank - bRank;
+        return String(a.data.city || "").localeCompare(String(b.data.city || ""));
+      });
   });
 
   eleventyConfig.addPassthroughCopy("site/assets");

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
     paths:
       - 'engineers/*.md'
+      - 'chapters/**'
       - 'jobs/**'
       - 'site/**'
       - 'scripts/**'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This repository is an Eleventy-powered static site for the GRC Engineer Directory. Content lives in `engineers/*.md`; each file is one profile page and must follow the schema in `engineers/_template.md`. Site templates and page sources live under `site/`, especially `site/_includes/layouts/`, `site/_includes/partials/`, and `site/_data/`. Frontend assets are in `site/assets/css/` and `site/assets/js/`. Build output is generated into `_site/` and should not be committed by hand. Automation and validation rules live in `.github/workflows/`.
+This repository is an Eleventy-powered static site for the GRC Engineer Directory. Content lives in `engineers/*.md`; each file is one profile page and must follow the schema in `engineers/_template.md`. Chapter lead listings live in `chapters/*.md` and follow `chapters/_template.md`. Site templates and page sources live under `site/`, especially `site/_includes/layouts/`, `site/_includes/partials/`, and `site/_data/`. Frontend assets are in `site/assets/css/` and `site/assets/js/`. Build output is generated into `_site/` and should not be committed by hand. Automation and validation rules live in `.github/workflows/`.
 
 ## Build, Test, and Development Commands
 Install dependencies once with `npm install`. Use `npm run serve` to start Eleventy with live reload at `http://localhost:8080`. Use `npm run build` to generate the production site in `_site/`. There is no separate unit test suite; the main local verification step is a clean build plus checking the rendered pages in the dev server.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A community-driven directory of Governance, Risk, and Compliance (GRC) engineers
 
 **[Browse the Directory](https://directory.grcengclub.com/)** — search by specialization, framework, language, and availability.
 
+**[Chapter Leads](https://directory.grcengclub.com/chapters/)** — find GRC Engineering Club chapter presidents, VPs, and founding teams by city.
+
 ## Engineers
 
 <!-- BEGIN_ENGINEER_LIST -->
@@ -63,6 +65,12 @@ A community-driven directory of Governance, Risk, and Compliance (GRC) engineers
 | **[Valeri Milke](engineers/vamisec.md)** | Audit & Assurance, Cloud Security, Compliance Automation, Identity & Access Management, Incident Response, Offensive Security, Privacy, Risk Management, Security Architecture, Security Governance, Security Operations, Third-Party Risk, Vulnerability Management, AI Governance, Cloud Governance, DevSecOps, AI Pentesting, Agentic AI Threat Modeling, MAESTRO, STRIDE | CCPA, CJIS, CMMC, CMS ARC-AMPE, COBIT, CSA STAR, EU AI Act, FedRAMP, GAO Green Book, GDPR, GovRAMP, HIPAA, HITRUST, IRS Pub 1075, ISO 27001, ISO 27017, ISO 27018, ISO 42001, NIST 800-53, NIST 800-171, NIST AI RMF, NIST CSF, NIST RMF, PCI-DSS, SOC 2, StateRAMP | [GitHub](https://github.com/vamisec), [LinkedIn](https://www.linkedin.com/in/valeri-milke/) |
 | **[Vikram Sathish ASOKAN](engineers/vikramhkg75.md)** | Audit & Assurance, Compliance Automation, Privacy, Risk Management, AI Governance, DevSecOps | EU AI Act, GDPR, HIPAA, ISO 27001, ISO 27017, ISO 27018, ISO 27701, ISO 22301, ISO 42001, NIST 800-53, NIST 800-171, NIST CSF, SOC 2 | [GitHub](https://github.com/vikramhkg75), [LinkedIn](https://www.linkedin.com/in/vikram-asokan/) |
 <!-- END_ENGINEER_LIST -->
+
+## Chapter Leads
+
+Local chapter leadership is listed under [`chapters/`](chapters/). Each file is one city chapter with its leads (President, VP, and other roles). When a lead already has a directory profile, set their `github` so the chapter card links to it.
+
+To add or update a chapter, copy `chapters/_template.md` to `chapters/{slug}.md`, fill in the city and `leads` list, and open a PR.
 
 ## Add Yourself
 

--- a/chapters/_template.md
+++ b/chapters/_template.md
@@ -1,0 +1,28 @@
+---
+# REQUIRED FIELDS
+city: City, ST
+slug: city-st
+status: provisional
+# Options: official, provisional, open
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/city-st
+summary: One or two sentences about the chapter and its focus.
+
+# Leadership team (required: at least one lead)
+leads:
+  - name: Lead Full Name
+    role: President
+    # Optional: link to an existing directory profile
+    github: their-github-username
+    # Optional socials
+    linkedin: https://linkedin.com/in/their-profile
+
+# OPTIONAL
+members: 0
+meetings: Monthly
+---
+
+## About this chapter
+
+Brief notes about the chapter's focus, meeting style, or local GRC scene.

--- a/chapters/_template.md
+++ b/chapters/_template.md
@@ -19,7 +19,7 @@ leads:
     linkedin: https://linkedin.com/in/their-profile
 
 # OPTIONAL
-members: 0
+
 meetings: Monthly
 ---
 

--- a/chapters/_template.md
+++ b/chapters/_template.md
@@ -23,6 +23,4 @@ leads:
 meetings: Monthly
 ---
 
-## About this chapter
-
 Brief notes about the chapter's focus, meeting style, or local GRC scene.

--- a/chapters/atlanta.md
+++ b/chapters/atlanta.md
@@ -1,0 +1,16 @@
+---
+city: Atlanta, GA
+slug: atlanta
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/atlanta
+members: 2
+meetings: Meeting schedule coming soon
+summary: The capital of the South has a massive security community and now a GRC engineering chapter to match.
+leads:
+  - name: Dwight Turner
+    role: President
+---
+
+Atlanta is building a local home for GRC practitioners who want to engineer compliance, not just document it.

--- a/chapters/atlanta.md
+++ b/chapters/atlanta.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/atlanta
-members: 2
+
 meetings: Meeting schedule coming soon
 summary: The capital of the South has a massive security community and now a GRC engineering chapter to match.
 leads:

--- a/chapters/austin.md
+++ b/chapters/austin.md
@@ -1,0 +1,20 @@
+---
+city: Austin, TX
+slug: austin
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/austin
+members: 5
+meetings: Monthly
+summary: A dense tech sector, big state-agency GRC, and a security community ready for the engineering side.
+leads:
+  - name: Angeline Williams
+    role: President
+    github: angie-in-the-cloud
+  - name: Jose Ruiz-Vazquez
+    role: Vice President
+    github: joseruiz1571
+---
+
+Austin's founding team came pre-assembled and is building toward official chapter status.

--- a/chapters/austin.md
+++ b/chapters/austin.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/austin
-members: 5
+
 meetings: Monthly
 summary: A dense tech sector, big state-agency GRC, and a security community ready for the engineering side.
 leads:

--- a/chapters/bay-area.md
+++ b/chapters/bay-area.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/bay-area
-members: 2
+
 meetings: Monthly
 summary: The Bay builds the tools — this chapter builds the practice across San Francisco and Oakland.
 leads:

--- a/chapters/bay-area.md
+++ b/chapters/bay-area.md
@@ -1,0 +1,16 @@
+---
+city: SF Bay Area, CA
+slug: bay-area
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/bay-area
+members: 2
+meetings: Monthly
+summary: The Bay builds the tools — this chapter builds the practice across San Francisco and Oakland.
+leads:
+  - name: Sierra Montoya
+    role: President
+---
+
+The SF Bay Area chapter turns tool builders into a local GRC engineering community.

--- a/chapters/boston.md
+++ b/chapters/boston.md
@@ -1,0 +1,18 @@
+---
+city: Boston, MA
+slug: boston
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/boston
+members: 3
+meetings: Meeting schedule coming soon
+summary: Healthcare, biotech, higher ed, and defense all within twenty minutes — each with its own regulatory world.
+leads:
+  - name: Susan Shepard
+    role: President
+  - name: Sergio Alonso
+    role: Vice President
+---
+
+Boston builds compliance into systems across healthcare, biotech, higher ed, and defense.

--- a/chapters/boston.md
+++ b/chapters/boston.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/boston
-members: 3
+
 meetings: Meeting schedule coming soon
 summary: Healthcare, biotech, higher ed, and defense all within twenty minutes — each with its own regulatory world.
 leads:

--- a/chapters/chapters.11tydata.js
+++ b/chapters/chapters.11tydata.js
@@ -1,0 +1,23 @@
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null || value === "") return [];
+  return [value];
+}
+
+module.exports = {
+  layout: "layouts/chapter.njk",
+  permalink: (data) => "chapters/" + (data.slug || data.page.fileSlug) + "/index.html",
+  tags: "chapters-content",
+  eleventyComputed: {
+    slug: (data) => data.slug || data.page.fileSlug,
+    status: (data) => data.status || "provisional",
+    leads: (data) => asArray(data.leads).filter((lead) => lead && lead.name),
+    description: (data) =>
+      data.description ||
+      (data.city
+        ? "GRC Engineering Club chapter leads in " + data.city
+        : "GRC Engineering Club chapter leads"),
+    eleventyExcludeFromCollections: (data) =>
+      String(data.page.fileSlug || "").startsWith("_")
+  }
+};

--- a/chapters/chapters.11tydata.js
+++ b/chapters/chapters.11tydata.js
@@ -10,6 +10,10 @@ module.exports = {
   tags: "chapters-content",
   eleventyComputed: {
     slug: (data) => data.slug || data.page.fileSlug,
+    title: (data) =>
+      data.city
+        ? data.city + " Chapter Leads - GRC Engineer Directory"
+        : "Chapter Leads - GRC Engineer Directory",
     status: (data) => data.status || "provisional",
     leads: (data) => asArray(data.leads).filter((lead) => lead && lead.name),
     description: (data) =>

--- a/chapters/chicago.md
+++ b/chapters/chicago.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/chicago
-members: 5
+
 meetings: Monthly
 summary: Top-five Fortune 500 headquarters density and a security scene to match.
 leads:

--- a/chapters/chicago.md
+++ b/chapters/chicago.md
@@ -1,0 +1,18 @@
+---
+city: Chicago, IL
+slug: chicago
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/chicago
+members: 5
+meetings: Monthly
+summary: Top-five Fortune 500 headquarters density and a security scene to match.
+leads:
+  - name: Salmaan Khan
+    role: President
+  - name: Kyle McCormick
+    role: Vice President
+---
+
+Chicagoland finally gets a GRC engineering home base.

--- a/chapters/dallas.md
+++ b/chapters/dallas.md
@@ -1,0 +1,16 @@
+---
+city: Dallas, TX
+slug: dallas
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/dallas
+members: 2
+meetings: Monthly virtual, quarterly in-person
+summary: An anticheckbox tour stop with Texas-sized opportunity for a founding chapter team.
+leads:
+  - name: Lauren Alex-Igwe
+    role: President
+---
+
+Dallas is organizing monthly virtual sessions with quarterly in-person meetups.

--- a/chapters/dallas.md
+++ b/chapters/dallas.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/dallas
-members: 2
+
 meetings: Monthly virtual, quarterly in-person
 summary: An anticheckbox tour stop with Texas-sized opportunity for a founding chapter team.
 leads:

--- a/chapters/detroit-metro.md
+++ b/chapters/detroit-metro.md
@@ -1,0 +1,19 @@
+---
+city: Detroit Metro, MI
+slug: detroit-metro
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/detroit-metro
+members: 1
+meetings: Monthly
+summary: Ann Arbor talent and Lansing state-government security across Novi, Troy, Livonia, and Plymouth.
+leads:
+  - name: Mike Hiltz
+    role: President
+  - name: Zahid Kamil
+    role: Vice President
+    github: ZahidKamil
+---
+
+Detroit Metro is one chapter for a corridor that does not do pretty — it does Detroit GRC.

--- a/chapters/detroit-metro.md
+++ b/chapters/detroit-metro.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/detroit-metro
-members: 1
+
 meetings: Monthly
 summary: Ann Arbor talent and Lansing state-government security across Novi, Troy, Livonia, and Plymouth.
 leads:

--- a/chapters/hartford.md
+++ b/chapters/hartford.md
@@ -1,0 +1,19 @@
+---
+city: Hartford, CT
+slug: hartford
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/hartford
+members: 3
+meetings: Meeting schedule coming soon
+summary: Connecticut's insurance capital meets compliance engineering across Hartford, Westbrook, and the shoreline.
+leads:
+  - name: Tiffany Walker-Roper
+    role: President
+    github: tiffanymwr15
+  - name: Michelle Cummings
+    role: Vice President
+---
+
+Hartford connects insurance-heavy GRC work with the club's engineering practice.

--- a/chapters/hartford.md
+++ b/chapters/hartford.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/hartford
-members: 3
+
 meetings: Meeting schedule coming soon
 summary: Connecticut's insurance capital meets compliance engineering across Hartford, Westbrook, and the shoreline.
 leads:

--- a/chapters/hyderabad.md
+++ b/chapters/hyderabad.md
@@ -5,7 +5,7 @@ status: provisional
 country: India
 region: Asia
 chapter_url: https://grcengclub.com/chapters/hyderabad
-members: 2
+
 meetings: Monthly virtual, twice-yearly in person
 summary: One of India's biggest tech hubs — the club's first chapter in Asia.
 leads:

--- a/chapters/hyderabad.md
+++ b/chapters/hyderabad.md
@@ -1,0 +1,19 @@
+---
+city: Hyderabad, India
+slug: hyderabad
+status: provisional
+country: India
+region: Asia
+chapter_url: https://grcengclub.com/chapters/hyderabad
+members: 2
+meetings: Monthly virtual, twice-yearly in person
+summary: One of India's biggest tech hubs — the club's first chapter in Asia.
+leads:
+  - name: Pradeep Reddy Sama
+    role: President
+    github: iampradeeprs
+  - name: Manisha Kotha
+    role: Vice President
+---
+
+Hyderabad gives GRC engineers their own room alongside the city's ISACA and ISC2 activity.

--- a/chapters/los-angeles.md
+++ b/chapters/los-angeles.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/los-angeles
-members: 0
+
 meetings: Monthly
 summary: LA's IT and cyber community already runs deep — now GRC Engineering gets its own room.
 leads:

--- a/chapters/los-angeles.md
+++ b/chapters/los-angeles.md
@@ -1,0 +1,19 @@
+---
+city: Los Angeles, CA
+slug: los-angeles
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/los-angeles
+members: 0
+meetings: Monthly
+summary: LA's IT and cyber community already runs deep — now GRC Engineering gets its own room.
+leads:
+  - name: Joseph Krikorian
+    role: President
+  - name: Nelson Rosario
+    role: Vice President
+    github: nelsonrosario89
+---
+
+Los Angeles adds a GRC Engineering chapter alongside ISSA, ISACA, OWASP, AITP, and CSA meetups.

--- a/chapters/nairobi.md
+++ b/chapters/nairobi.md
@@ -1,0 +1,18 @@
+---
+city: Nairobi, Kenya
+slug: nairobi
+status: provisional
+country: Kenya
+region: Africa
+chapter_url: https://grcengclub.com/chapters/nairobi
+members: 4
+meetings: Meeting schedule coming soon
+summary: The club's first chapter in Africa, launched with a full founding team in East Africa's tech capital.
+leads:
+  - name: Ruby Njoroge
+    role: President
+  - name: Christian Kisutsa
+    role: Vice President
+---
+
+Nairobi is the founding African chapter for GRC Engineering Club.

--- a/chapters/nairobi.md
+++ b/chapters/nairobi.md
@@ -5,7 +5,7 @@ status: provisional
 country: Kenya
 region: Africa
 chapter_url: https://grcengclub.com/chapters/nairobi
-members: 4
+
 meetings: Meeting schedule coming soon
 summary: The club's first chapter in Africa, launched with a full founding team in East Africa's tech capital.
 leads:

--- a/chapters/nashville.md
+++ b/chapters/nashville.md
@@ -1,0 +1,17 @@
+---
+city: Nashville, TN
+slug: nashville
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/nashville
+members: 3
+meetings: Monthly
+summary: A community for cybersecurity professionals who want to move beyond documentation and into automation.
+leads:
+  - name: Jonathan Steward
+    role: President
+    github: jonathansteward
+---
+
+Nashville focuses on cloud infrastructure, Infrastructure as Code, policy-as-code, AI, and compliance automation.

--- a/chapters/nashville.md
+++ b/chapters/nashville.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/nashville
-members: 3
+
 meetings: Monthly
 summary: A community for cybersecurity professionals who want to move beyond documentation and into automation.
 leads:

--- a/chapters/nyc.md
+++ b/chapters/nyc.md
@@ -1,0 +1,16 @@
+---
+city: New York City, NY
+slug: nyc
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/nyc
+members: 6
+meetings: Bi-monthly
+summary: Finance, fintech, and Big 4 density — more GRC practitioners per square mile than anywhere on earth.
+leads:
+  - name: Iqra Malik
+    role: President
+---
+
+New York City gives GRC engineers an engineering-first home in the densest market in the club.

--- a/chapters/nyc.md
+++ b/chapters/nyc.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/nyc
-members: 6
+
 meetings: Bi-monthly
 summary: Finance, fintech, and Big 4 density — more GRC practitioners per square mile than anywhere on earth.
 leads:

--- a/chapters/philadelphia.md
+++ b/chapters/philadelphia.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/philadelphia
-members: 2
+
 meetings: Meeting schedule coming soon
 summary: A financial hub in NYC's orbit with major insurers and enterprises headquartered downtown.
 leads:

--- a/chapters/philadelphia.md
+++ b/chapters/philadelphia.md
@@ -1,0 +1,18 @@
+---
+city: Philadelphia, PA
+slug: philadelphia
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/philadelphia
+members: 2
+meetings: Meeting schedule coming soon
+summary: A financial hub in NYC's orbit with major insurers and enterprises headquartered downtown.
+leads:
+  - name: Daniel Dragone
+    role: President
+  - name: James Robinson
+    role: Vice President
+---
+
+Philly's chapter is led from inside the local enterprise and insurance GRC scene.

--- a/chapters/raleigh.md
+++ b/chapters/raleigh.md
@@ -1,0 +1,19 @@
+---
+city: Raleigh, NC
+slug: raleigh
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/raleigh
+members: 7
+meetings: Quarterly, Research Triangle venues
+summary: The Research Triangle is one of the club's biggest clusters, and its chapter runs on hands-on build sessions.
+leads:
+  - name: John Flack
+    role: President
+    github: jtflack-grc
+  - name: Adarian Dewberry
+    role: Vice President
+---
+
+Raleigh focuses on practical build sessions across the Research Triangle.

--- a/chapters/raleigh.md
+++ b/chapters/raleigh.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/raleigh
-members: 7
+
 meetings: Quarterly, Research Triangle venues
 summary: The Research Triangle is one of the club's biggest clusters, and its chapter runs on hands-on build sessions.
 leads:

--- a/chapters/seattle.md
+++ b/chapters/seattle.md
@@ -1,0 +1,16 @@
+---
+city: Seattle, WA
+slug: seattle
+status: provisional
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/seattle
+members: 1
+meetings: Monthly, in-person
+summary: Aerospace and defense compliance plus a real slice of government cloud infrastructure.
+leads:
+  - name: Anton Nikitin
+    role: President
+---
+
+Seattle focuses on CMMC, ITAR, Space Force, and government cloud compliance engineering.

--- a/chapters/seattle.md
+++ b/chapters/seattle.md
@@ -5,7 +5,7 @@ status: provisional
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/seattle
-members: 1
+
 meetings: Monthly, in-person
 summary: Aerospace and defense compliance plus a real slice of government cloud infrastructure.
 leads:

--- a/chapters/stockholm.md
+++ b/chapters/stockholm.md
@@ -1,0 +1,16 @@
+---
+city: Stockholm, Sweden
+slug: stockholm
+status: provisional
+country: Sweden
+region: Europe
+chapter_url: https://grcengclub.com/chapters/stockholm
+members: 1
+meetings: Quarterly
+summary: The club's first Nordic chapter in a global AI hub that was doing GRC engineering before the term existed.
+leads:
+  - name: Nikola Glad Latinovic
+    role: President
+---
+
+Stockholm anchors the Nordic chapter network for compliance engineering and AI-era GRC.

--- a/chapters/stockholm.md
+++ b/chapters/stockholm.md
@@ -5,7 +5,7 @@ status: provisional
 country: Sweden
 region: Europe
 chapter_url: https://grcengclub.com/chapters/stockholm
-members: 1
+
 meetings: Quarterly
 summary: The club's first Nordic chapter in a global AI hub that was doing GRC engineering before the term existed.
 leads:

--- a/chapters/toronto.md
+++ b/chapters/toronto.md
@@ -5,7 +5,7 @@ status: provisional
 country: Canada
 region: North America
 chapter_url: https://grcengclub.com/chapters/toronto
-members: 4
+
 meetings: Meeting schedule coming soon
 summary: Canada's financial capital — the Big Five banks, OSFI, and a fintech corridor stretching to Waterloo.
 leads:

--- a/chapters/toronto.md
+++ b/chapters/toronto.md
@@ -1,0 +1,17 @@
+---
+city: Toronto, Canada
+slug: toronto
+status: provisional
+country: Canada
+region: North America
+chapter_url: https://grcengclub.com/chapters/toronto
+members: 4
+meetings: Meeting schedule coming soon
+summary: Canada's financial capital — the Big Five banks, OSFI, and a fintech corridor stretching to Waterloo.
+leads:
+  - name: Debjyoti Mukherjee
+    role: President
+    github: debjym
+---
+
+Toronto gives compliance engineering a home in Canada's financial and fintech corridor.

--- a/chapters/washington-dc.md
+++ b/chapters/washington-dc.md
@@ -1,0 +1,22 @@
+---
+city: Washington, DC
+slug: washington-dc
+status: official
+country: United States
+region: North America
+chapter_url: https://grcengclub.com/chapters/washington-dc
+members: 20
+meetings: Monthly virtual, quarterly in person
+summary: The federal compliance capital of the world, covering NOVA, Reston, Fort Washington, and the broader DMV.
+leads:
+  - name: Gopal Kharbanda
+    role: President
+  - name: Jonathan Perez
+    role: Vice President
+    github: GRCJP
+  - name: Dex-Xavier Copeland
+    role: Head of Growth & Training
+    github: dexcopeland
+---
+
+The DMV chapter launched with a full founding leadership team and is the club's first official chapter.

--- a/chapters/washington-dc.md
+++ b/chapters/washington-dc.md
@@ -5,7 +5,7 @@ status: official
 country: United States
 region: North America
 chapter_url: https://grcengclub.com/chapters/washington-dc
-members: 20
+
 meetings: Monthly virtual, quarterly in person
 summary: The federal compliance capital of the world, covering NOVA, Reston, Fort Washington, and the broader DMV.
 leads:

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -25,6 +25,7 @@
       <a href="/" class="nav-brand">GRC Engineer Directory</a>
       <div class="nav-links">
         <a href="/" class="nav-link">Engineers</a>
+        <a href="/chapters/" class="nav-link">Chapter Leads</a>
         <a href="/jobs/" class="nav-link">Jobs</a>
         <a href="https://grcengclub.com" class="nav-link" target="_blank" rel="noopener">grcengclub.com</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle light/dark mode"></button>
@@ -41,6 +42,7 @@
     <div class="footer-inner">
       <p>Part of the <a href="https://grcengclub.com" target="_blank" rel="noopener">GRC Engineering Club</a></p>
       <p><a href="/submit/">Submit your profile</a> to join the directory.</p>
+      <p><a href="/chapters/">Meet GRC Engineering chapter leads</a> organizing local communities.</p>
       <p><a href="/jobs/">Browse open GRC engineering roles</a> from the club's community resource.</p>
     </div>
   </footer>

--- a/site/_includes/layouts/chapter.njk
+++ b/site/_includes/layouts/chapter.njk
@@ -67,7 +67,7 @@ layout: layouts/base.njk
     </div>
   </section>
 
-  {% if content %}
+  {% if content | trim %}
   <section class="chapter-page-section chapter-page-body">
     <h2>About this chapter</h2>
     {{ content | safe }}

--- a/site/_includes/layouts/chapter.njk
+++ b/site/_includes/layouts/chapter.njk
@@ -1,0 +1,76 @@
+---
+layout: layouts/base.njk
+---
+{% set leads = leads or [] %}
+<article class="chapter-page">
+  <div class="chapter-page-back">
+    <a href="/chapters/">&larr; Back to chapter leads</a>
+  </div>
+
+  <header class="chapter-page-header">
+    <p class="jobs-kicker">Chapter Leads</p>
+    <p class="chapter-status chapter-status-{{ status | slugify }}">{{ status }}</p>
+    <h1>{{ city }}</h1>
+    {% if summary %}
+    <p class="chapter-page-summary">{{ summary }}</p>
+    {% endif %}
+    <div class="chapter-page-meta">
+      {% if region %}<span>{{ region }}</span>{% endif %}
+      {% if country %}<span>{{ country }}</span>{% endif %}
+      {% if members %}<span>{{ members }} members</span>{% endif %}
+      {% if meetings %}<span>{{ meetings }}</span>{% endif %}
+    </div>
+    <div class="chapter-page-actions">
+      {% if chapter_url %}
+      <a href="{{ chapter_url }}" class="btn btn-primary" target="_blank" rel="noopener">Visit chapter page</a>
+      {% endif %}
+      <a href="https://grcengclub.com/chapters" class="btn btn-outline" target="_blank" rel="noopener">Start a chapter</a>
+    </div>
+  </header>
+
+  <section class="chapter-page-section">
+    <h2>Leadership team</h2>
+    <div class="chapter-lead-grid">
+      {% for lead in leads %}
+      <article class="chapter-lead-card">
+        {% if lead.github %}
+        <img
+          src="https://github.com/{{ lead.github }}.png?size=120"
+          alt="{{ lead.name }}"
+          class="chapter-lead-avatar"
+          width="64"
+          height="64"
+          loading="lazy"
+        >
+        {% else %}
+        <div class="chapter-lead-avatar chapter-lead-avatar-fallback" aria-hidden="true">{{ lead.name[0] }}</div>
+        {% endif %}
+        <div>
+          {% if lead.github %}
+          <a href="/engineers/{{ lead.github }}/" class="card-name">{{ lead.name }}</a>
+          {% else %}
+          <p class="card-name">{{ lead.name }}</p>
+          {% endif %}
+          <p class="chapter-lead-role">{{ lead.role }}</p>
+          <div class="chapter-lead-links">
+            {% if lead.github %}
+            <a href="/engineers/{{ lead.github }}/">Directory profile</a>
+            <a href="https://github.com/{{ lead.github }}" target="_blank" rel="noopener">GitHub</a>
+            {% endif %}
+            {% if lead.linkedin %}
+            <a href="{{ lead.linkedin }}" target="_blank" rel="noopener">LinkedIn</a>
+            {% endif %}
+          </div>
+        </div>
+      </article>
+      {% endfor %}
+    </div>
+  </section>
+
+  {% if content %}
+  <section class="chapter-page-section chapter-page-body">
+    <h2>About this chapter</h2>
+    {{ content | safe }}
+  </section>
+  {% endif %}
+</article>

--- a/site/_includes/partials/chapter-card.njk
+++ b/site/_includes/partials/chapter-card.njk
@@ -1,0 +1,65 @@
+{% set leads = chapter.data.leads or [] %}
+<article
+  class="card chapter-card"
+  data-city="{{ chapter.data.city | lower }}"
+  data-region="{{ (chapter.data.region or '') | lower }}"
+  data-country="{{ (chapter.data.country or '') | lower }}"
+  data-status="{{ (chapter.data.status or '') | lower }}"
+  data-leads="{% for lead in leads %}{{ lead.name }}{% if not loop.last %},{% endif %}{% endfor %}"
+  data-roles="{% for lead in leads %}{{ lead.role }}{% if not loop.last %},{% endif %}{% endfor %}"
+>
+  <div class="chapter-card-top">
+    <div>
+      <p class="chapter-status chapter-status-{{ chapter.data.status | slugify }}">{{ chapter.data.status }}</p>
+      <a href="{{ chapter.url }}" class="card-name chapter-card-city">{{ chapter.data.city }}</a>
+      {% if chapter.data.region or chapter.data.country %}
+      <p class="chapter-card-location">
+        {% if chapter.data.region %}{{ chapter.data.region }}{% endif %}
+        {% if chapter.data.region and chapter.data.country %} · {% endif %}
+        {% if chapter.data.country %}{{ chapter.data.country }}{% endif %}
+      </p>
+      {% endif %}
+    </div>
+    {% if chapter.data.members %}
+    <p class="chapter-card-members"><strong>{{ chapter.data.members }}</strong> members</p>
+    {% endif %}
+  </div>
+
+  {% if chapter.data.summary %}
+  <p class="chapter-card-summary">{{ chapter.data.summary }}</p>
+  {% endif %}
+
+  <div class="chapter-card-leads" aria-label="Chapter leads">
+    {% for lead in leads %}
+    <div class="chapter-card-lead">
+      {% if lead.github %}
+      <img
+        src="https://github.com/{{ lead.github }}.png?size=80"
+        alt=""
+        class="chapter-card-lead-avatar"
+        width="36"
+        height="36"
+        loading="lazy"
+      >
+      {% else %}
+      <span class="chapter-card-lead-avatar chapter-lead-avatar-fallback" aria-hidden="true">{{ lead.name[0] }}</span>
+      {% endif %}
+      <div>
+        {% if lead.github %}
+        <a href="/engineers/{{ lead.github }}/" class="chapter-card-lead-name">{{ lead.name }}</a>
+        {% else %}
+        <span class="chapter-card-lead-name">{{ lead.name }}</span>
+        {% endif %}
+        <p class="chapter-lead-role">{{ lead.role }}</p>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <div class="chapter-card-actions">
+    <a href="{{ chapter.url }}" class="btn btn-outline btn-compact">View leads</a>
+    {% if chapter.data.chapter_url %}
+    <a href="{{ chapter.data.chapter_url }}" class="btn btn-primary btn-compact" target="_blank" rel="noopener">Chapter page</a>
+    {% endif %}
+  </div>
+</article>

--- a/site/_includes/partials/chapter-filter-bar.njk
+++ b/site/_includes/partials/chapter-filter-bar.njk
@@ -1,43 +1,51 @@
-<aside class="filters" id="filters" aria-label="Filter chapter leads">
-  <div class="filters-inner">
+<aside class="filters" id="chapter-filters" aria-label="Filter chapter leads">
+  <div class="filters-expanded-panel">
+    <div class="controls-header">
+      <p class="results-count" aria-live="polite" aria-atomic="true">
+        <span id="result-count">{{ collections.chapters.length }}</span> of {{ collections.chapters.length }} chapters
+      </p>
+    </div>
+
     <div class="controls-bar">
-      <div class="controls-left">
-        <label class="search-wrap" for="search">
-          <span class="sr-only">Search chapter leads</span>
-          <input
-            type="search"
-            id="search"
-            class="search-input"
-            placeholder="Search by city, lead name, or role..."
-            autocomplete="off"
-          >
-        </label>
-        <div class="controls-meta" aria-label="Chapter coverage">
-          <span class="controls-count"><strong id="result-count">{{ collections.chapters.length }}</strong> chapters</span>
-        </div>
+      <div class="search-box">
+        <input
+          type="search"
+          id="chapter-search-input"
+          placeholder="Search by city, lead name, or role..."
+          aria-label="Search chapter leads"
+          autocomplete="off"
+        >
       </div>
     </div>
 
-    <div class="filter-groups">
-      <div class="filter-group">
-        <div class="filter-group-header">
-          <span>Status</span>
-        </div>
-        <div class="filter-chips" data-filter="status">
-          {% for status in collections.chapters | uniqueValues("status") %}
-          <button type="button" class="filter-chip" data-value="{{ status | lower }}">{{ status }}</button>
-          {% endfor %}
-        </div>
+    <div class="filter-workbench">
+      <div class="filter-workbench-header">
+        <span>Filter by</span>
       </div>
 
-      <div class="filter-group">
-        <div class="filter-group-header">
-          <span>Region</span>
+      <div class="filter-groups">
+        <div class="filter-group open" data-group="status">
+          <button type="button" class="filter-group-header" aria-expanded="true">
+            <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+            <span>Status</span>
+          </button>
+          <div class="filter-chips" data-filter="status">
+            {% for status in collections.chapters | uniqueValues("status") %}
+            <button type="button" class="chip" data-value="{{ status | lower }}" aria-pressed="false">{{ status }}</button>
+            {% endfor %}
+          </div>
         </div>
-        <div class="filter-chips" data-filter="region">
-          {% for region in collections.chapters | uniqueValues("region") %}
-          <button type="button" class="filter-chip" data-value="{{ region | lower }}">{{ region }}</button>
-          {% endfor %}
+
+        <div class="filter-group" data-group="region">
+          <button type="button" class="filter-group-header" aria-expanded="false">
+            <svg class="chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+            <span>Region</span>
+          </button>
+          <div class="filter-chips" data-filter="region">
+            {% for region in collections.chapters | uniqueValues("region") %}
+            <button type="button" class="chip" data-value="{{ region | lower }}" aria-pressed="false">{{ region }}</button>
+            {% endfor %}
+          </div>
         </div>
       </div>
     </div>

--- a/site/_includes/partials/chapter-filter-bar.njk
+++ b/site/_includes/partials/chapter-filter-bar.njk
@@ -1,0 +1,45 @@
+<aside class="filters" id="filters" aria-label="Filter chapter leads">
+  <div class="filters-inner">
+    <div class="controls-bar">
+      <div class="controls-left">
+        <label class="search-wrap" for="search">
+          <span class="sr-only">Search chapter leads</span>
+          <input
+            type="search"
+            id="search"
+            class="search-input"
+            placeholder="Search by city, lead name, or role..."
+            autocomplete="off"
+          >
+        </label>
+        <div class="controls-meta" aria-label="Chapter coverage">
+          <span class="controls-count"><strong id="result-count">{{ collections.chapters.length }}</strong> chapters</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="filter-groups">
+      <div class="filter-group">
+        <div class="filter-group-header">
+          <span>Status</span>
+        </div>
+        <div class="filter-chips" data-filter="status">
+          {% for status in collections.chapters | uniqueValues("status") %}
+          <button type="button" class="filter-chip" data-value="{{ status | lower }}">{{ status }}</button>
+          {% endfor %}
+        </div>
+      </div>
+
+      <div class="filter-group">
+        <div class="filter-group-header">
+          <span>Region</span>
+        </div>
+        <div class="filter-chips" data-filter="region">
+          {% for region in collections.chapters | uniqueValues("region") %}
+          <button type="button" class="filter-chip" data-value="{{ region | lower }}">{{ region }}</button>
+          {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</aside>

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -971,18 +971,18 @@ a:hover {
 }
 
 @media (min-width: 900px) {
-  .directory:not(.jobs-directory) {
+  .directory:not(.jobs-directory):not(.chapters-directory) {
     max-width: none;
     padding-left: 0;
     padding-right: 0;
   }
-  .directory:not(.jobs-directory) .directory-toolbar,
-  .directory:not(.jobs-directory) .card-grid {
+  .directory:not(.jobs-directory):not(.chapters-directory) .directory-toolbar,
+  .directory:not(.jobs-directory):not(.chapters-directory) .card-grid {
     max-width: 1200px;
     margin-left: auto;
     margin-right: auto;
   }
-  .directory:not(.jobs-directory) .directory-toolbar {
+  .directory:not(.jobs-directory):not(.chapters-directory) .directory-toolbar {
     display: grid;
     grid-template-columns: minmax(250px, 1.25fr) minmax(150px, 0.7fr) minmax(210px, 1fr) minmax(210px, 1fr) minmax(190px, 0.85fr);
     gap: 1rem;
@@ -996,7 +996,7 @@ a:hover {
     border-radius: var(--radius) var(--radius) 0 0;
     background: var(--bg-tertiary);
   }
-  .directory:not(.jobs-directory) .card-grid {
+  .directory:not(.jobs-directory):not(.chapters-directory) .card-grid {
     display: block;
     border: 1px solid var(--border-subtle);
     border-top: none;

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1114,6 +1114,13 @@ a:hover {
 }
 
 /* Chapters */
+#chapter-filters .filter-groups {
+  min-height: 6rem;
+}
+#chapter-filters .filter-group.open .filter-chips {
+  grid-row: 1 / 3;
+  max-height: 6rem;
+}
 .chapters-hero .chapter-page-actions {
   margin-top: 1.25rem;
 }

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -1113,6 +1113,225 @@ a:hover {
   }
 }
 
+/* Chapters */
+.chapters-hero .chapter-page-actions {
+  margin-top: 1.25rem;
+}
+.chapters-preview {
+  padding-top: 1.5rem;
+}
+.chapters-preview-grid,
+.chapters-grid {
+  align-items: stretch;
+}
+.chapter-card {
+  display: grid;
+  gap: 1rem;
+}
+.chapter-card-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+.chapter-card-city {
+  display: inline-block;
+  font-size: 1.15rem;
+  margin-top: 0.2rem;
+}
+.chapter-card-location,
+.chapter-card-summary,
+.chapter-lead-role {
+  color: var(--text-secondary);
+}
+.chapter-card-location {
+  margin-top: 0.25rem;
+  font-size: 0.9rem;
+}
+.chapter-card-summary {
+  margin: 0;
+  line-height: 1.45;
+}
+.chapter-card-members {
+  margin: 0;
+  text-align: right;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+.chapter-card-members strong {
+  display: block;
+  color: var(--text-primary);
+  font-size: 1.1rem;
+}
+.chapter-status {
+  display: inline-block;
+  margin: 0 0 0.35rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--brand-primary);
+}
+.chapter-status-official {
+  color: var(--available-color);
+}
+.chapter-status-open {
+  color: var(--text-secondary);
+}
+.chapter-card-leads {
+  display: grid;
+  gap: 0.75rem;
+}
+.chapter-card-lead {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+  min-width: 0;
+}
+.chapter-card-lead-avatar,
+.chapter-lead-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--bg-tertiary);
+}
+.chapter-lead-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  color: var(--text-primary);
+  border: 1px solid var(--border-subtle);
+}
+.chapter-card-lead-name {
+  color: var(--text-primary);
+  font-weight: 600;
+  text-decoration: none;
+}
+.chapter-card-lead-name:hover {
+  color: var(--brand-primary);
+}
+.chapter-lead-role {
+  margin: 0.1rem 0 0;
+  font-size: 0.85rem;
+}
+.chapter-card-actions,
+.chapter-page-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+.chapter-card-actions {
+  margin-top: auto;
+  padding-top: 0.25rem;
+}
+.chapter-page {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 2rem 1.5rem 3rem;
+}
+.chapter-page-back {
+  margin-bottom: 1.25rem;
+}
+.chapter-page-back a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+.chapter-page-back a:hover {
+  color: var(--brand-primary);
+}
+.chapter-page-header {
+  background:
+    radial-gradient(circle at top right, var(--brand-primary-20), transparent 42%),
+    var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.chapter-page-header h1 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  line-height: 1.05;
+  margin: 0.35rem 0 0.85rem;
+}
+.chapter-page-summary {
+  max-width: 60ch;
+  color: var(--text-secondary);
+  margin: 0 0 1rem;
+}
+.chapter-page-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 1rem;
+  margin-bottom: 1.25rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+.chapter-page-section {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1rem;
+}
+.chapter-page-section h2 {
+  margin: 0 0 1rem;
+}
+.chapter-lead-grid {
+  display: grid;
+  gap: 1rem;
+}
+.chapter-lead-card {
+  display: flex;
+  gap: 0.9rem;
+  align-items: center;
+  padding: 0.85rem 0;
+  border-top: 1px solid var(--border-subtle);
+}
+.chapter-lead-card:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+.chapter-lead-avatar {
+  width: 64px;
+  height: 64px;
+}
+.chapter-lead-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.4rem;
+  font-size: 0.9rem;
+}
+.chapter-lead-links a {
+  color: var(--brand-primary);
+  text-decoration: none;
+}
+.chapter-lead-links a:hover {
+  text-decoration: underline;
+}
+.chapter-page-body :first-child {
+  margin-top: 0;
+}
+.chapters-directory {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+}
+.chapters-toolbar {
+  display: none;
+}
+
+@media (min-width: 900px) {
+  .chapters-preview-grid,
+  .chapters-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
 /* Jobs */
 .jobs-hero,
 .jobs-preview,
@@ -2177,9 +2396,21 @@ a:hover {
   .jobs-hero,
   .jobs-preview,
   .jobs-notes,
-  .job-page {
+  .job-page,
+  .chapters-directory,
+  .chapter-page {
     padding-left: 1rem;
     padding-right: 1rem;
+  }
+  .chapter-card-top {
+    flex-direction: column;
+  }
+  .chapter-card-members {
+    text-align: left;
+  }
+  .chapter-card-members strong {
+    display: inline;
+    margin-right: 0.25rem;
   }
   .jobs-preview-header {
     flex-direction: column;

--- a/site/assets/js/chapters-search.js
+++ b/site/assets/js/chapters-search.js
@@ -1,9 +1,10 @@
 (function () {
-  var searchInput = document.getElementById("search");
+  var filterRoot = document.getElementById("chapter-filters");
+  var searchInput = document.getElementById("chapter-search-input");
   var cardGrid = document.querySelector(".chapters-directory .card-grid");
   var resultCount = document.getElementById("result-count");
   var noResults = document.getElementById("no-results");
-  if (!cardGrid) return;
+  if (!filterRoot || !cardGrid) return;
 
   var cards = Array.prototype.slice.call(cardGrid.querySelectorAll(".chapter-card"));
   var activeFilters = {
@@ -30,8 +31,7 @@
 
   function matchesFilter(card, key, value) {
     if (!value) return true;
-    var attr = card.getAttribute("data-" + key) || "";
-    return attr.indexOf(value) !== -1;
+    return normalize(card.getAttribute("data-" + key)) === value;
   }
 
   function applyFilters() {
@@ -52,35 +52,90 @@
     if (noResults) noResults.style.display = visible ? "none" : "block";
   }
 
+  function syncMobileTabs() {
+    var openGroup = filterRoot.querySelector(".filter-group.open");
+    Array.prototype.forEach.call(filterRoot.querySelectorAll(".filter-mobile-tab"), function (tab) {
+      var isActive = openGroup && tab.getAttribute("data-group") === openGroup.getAttribute("data-group");
+      tab.classList.toggle("active", Boolean(isActive));
+      tab.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
+  }
+
+  function setOpenGroup(group) {
+    if (!group) return;
+    Array.prototype.forEach.call(filterRoot.querySelectorAll(".filter-group"), function (other) {
+      var isOpen = other === group;
+      other.classList.toggle("open", isOpen);
+      var header = other.querySelector(".filter-group-header");
+      if (header) header.setAttribute("aria-expanded", isOpen ? "true" : "false");
+    });
+    syncMobileTabs();
+  }
+
+  function createMobileTabs() {
+    var groups = filterRoot.querySelector(".filter-groups");
+    var headers = filterRoot.querySelectorAll(".filter-group-header");
+    if (!groups || !headers.length || filterRoot.querySelector(".filter-mobile-tabs")) return;
+
+    var tabs = document.createElement("div");
+    tabs.className = "filter-mobile-tabs";
+    tabs.setAttribute("aria-label", "Chapter filter categories");
+
+    Array.prototype.forEach.call(headers, function (header) {
+      var group = header.closest(".filter-group");
+      if (!group) return;
+      var label = header.querySelector("span");
+      var tab = document.createElement("button");
+      tab.type = "button";
+      tab.className = "filter-mobile-tab";
+      tab.setAttribute("data-group", group.getAttribute("data-group") || "");
+      tab.setAttribute("aria-pressed", "false");
+      tab.textContent = label ? label.textContent : header.textContent.trim();
+      tab.addEventListener("click", function () {
+        setOpenGroup(group);
+      });
+      tabs.appendChild(tab);
+    });
+
+    groups.parentNode.insertBefore(tabs, groups);
+    syncMobileTabs();
+  }
+
   if (searchInput) {
     searchInput.addEventListener("input", applyFilters);
   }
 
-  Array.prototype.forEach.call(
-    document.querySelectorAll(".filter-chips[data-filter]"),
-    function (group) {
-      var key = group.getAttribute("data-filter");
-      Array.prototype.forEach.call(group.querySelectorAll(".filter-chip"), function (chip) {
-        chip.addEventListener("click", function () {
-          var value = chip.getAttribute("data-value");
-          var isActive = chip.classList.contains("active");
+  Array.prototype.forEach.call(filterRoot.querySelectorAll(".filter-group-header"), function (header) {
+    header.addEventListener("click", function () {
+      setOpenGroup(header.closest(".filter-group"));
+    });
+  });
 
-          Array.prototype.forEach.call(group.querySelectorAll(".filter-chip"), function (other) {
-            other.classList.remove("active");
-          });
+  Array.prototype.forEach.call(filterRoot.querySelectorAll(".filter-chips[data-filter]"), function (group) {
+    var key = group.getAttribute("data-filter");
+    Array.prototype.forEach.call(group.querySelectorAll(".chip"), function (chip) {
+      chip.addEventListener("click", function () {
+        var value = normalize(chip.getAttribute("data-value"));
+        var isActive = chip.classList.contains("active");
 
-          if (isActive) {
-            activeFilters[key] = null;
-          } else {
-            chip.classList.add("active");
-            activeFilters[key] = value;
-          }
-
-          applyFilters();
+        Array.prototype.forEach.call(group.querySelectorAll(".chip"), function (other) {
+          other.classList.remove("active");
+          other.setAttribute("aria-pressed", "false");
         });
-      });
-    }
-  );
 
+        if (isActive) {
+          activeFilters[key] = null;
+        } else {
+          chip.classList.add("active");
+          chip.setAttribute("aria-pressed", "true");
+          activeFilters[key] = value;
+        }
+
+        applyFilters();
+      });
+    });
+  });
+
+  createMobileTabs();
   applyFilters();
 })();

--- a/site/assets/js/chapters-search.js
+++ b/site/assets/js/chapters-search.js
@@ -1,0 +1,86 @@
+(function () {
+  var searchInput = document.getElementById("search");
+  var cardGrid = document.querySelector(".chapters-directory .card-grid");
+  var resultCount = document.getElementById("result-count");
+  var noResults = document.getElementById("no-results");
+  if (!cardGrid) return;
+
+  var cards = Array.prototype.slice.call(cardGrid.querySelectorAll(".chapter-card"));
+  var activeFilters = {
+    status: null,
+    region: null
+  };
+
+  function normalize(value) {
+    return String(value || "").toLowerCase().trim();
+  }
+
+  function matchesSearch(card, query) {
+    if (!query) return true;
+    var haystack = [
+      card.getAttribute("data-city"),
+      card.getAttribute("data-region"),
+      card.getAttribute("data-country"),
+      card.getAttribute("data-status"),
+      card.getAttribute("data-leads"),
+      card.getAttribute("data-roles")
+    ].join(" ").toLowerCase();
+    return haystack.indexOf(query) !== -1;
+  }
+
+  function matchesFilter(card, key, value) {
+    if (!value) return true;
+    var attr = card.getAttribute("data-" + key) || "";
+    return attr.indexOf(value) !== -1;
+  }
+
+  function applyFilters() {
+    var query = normalize(searchInput ? searchInput.value : "");
+    var visible = 0;
+
+    cards.forEach(function (card) {
+      var show =
+        matchesSearch(card, query) &&
+        matchesFilter(card, "status", activeFilters.status) &&
+        matchesFilter(card, "region", activeFilters.region);
+
+      card.classList.toggle("hidden", !show);
+      if (show) visible += 1;
+    });
+
+    if (resultCount) resultCount.textContent = String(visible);
+    if (noResults) noResults.style.display = visible ? "none" : "block";
+  }
+
+  if (searchInput) {
+    searchInput.addEventListener("input", applyFilters);
+  }
+
+  Array.prototype.forEach.call(
+    document.querySelectorAll(".filter-chips[data-filter]"),
+    function (group) {
+      var key = group.getAttribute("data-filter");
+      Array.prototype.forEach.call(group.querySelectorAll(".filter-chip"), function (chip) {
+        chip.addEventListener("click", function () {
+          var value = chip.getAttribute("data-value");
+          var isActive = chip.classList.contains("active");
+
+          Array.prototype.forEach.call(group.querySelectorAll(".filter-chip"), function (other) {
+            other.classList.remove("active");
+          });
+
+          if (isActive) {
+            activeFilters[key] = null;
+          } else {
+            chip.classList.add("active");
+            activeFilters[key] = value;
+          }
+
+          applyFilters();
+        });
+      });
+    }
+  );
+
+  applyFilters();
+})();

--- a/site/chapters.njk
+++ b/site/chapters.njk
@@ -1,0 +1,44 @@
+---
+layout: layouts/base.njk
+title: Chapter Leads - GRC Engineer Directory
+permalink: /chapters/index.html
+description: Meet the GRC Engineering Club chapter leads organizing local communities around the world.
+---
+<section class="jobs-hero chapters-hero">
+  <div class="jobs-hero-inner">
+    <p class="jobs-kicker">Chapter Leads</p>
+    <h1>GRC Engineering chapter leads</h1>
+    <p class="jobs-hero-copy">Local leaders organizing GRC Engineering Club chapters in cities around the world. Find a chapter near you, meet the founding team, and connect with the people building community on the ground.</p>
+    <div class="chapter-page-actions">
+      <a href="https://grcengclub.com/chapters" class="btn btn-primary" target="_blank" rel="noopener">Start a chapter</a>
+      <a href="/" class="btn btn-outline">Browse engineers</a>
+    </div>
+  </div>
+</section>
+
+{% include "partials/chapter-filter-bar.njk" %}
+
+<section class="directory chapters-directory">
+  {% if collections.chapters.length %}
+  <div class="directory-toolbar chapters-toolbar">
+    <span>Chapter</span>
+    <span>Leads</span>
+    <span>Actions</span>
+  </div>
+  <div class="card-grid chapters-grid">
+    {% for chapter in collections.chapters %}
+      {% include "partials/chapter-card.njk" %}
+    {% endfor %}
+  </div>
+  {% else %}
+  <div class="jobs-empty">
+    <h2>No chapter leads listed yet</h2>
+    <p>Add a chapter file under <code>chapters/</code> using <code>chapters/_template.md</code> to list its leadership team here.</p>
+  </div>
+  {% endif %}
+
+  <p id="no-results" class="no-results" style="display:none" aria-live="polite">No chapters match your filters. Try removing a filter or broadening the search.</p>
+</section>
+
+<script src="/site/assets/js/chapters-search.js"></script>
+<script src="/site/assets/js/filter-scroll.js"></script>

--- a/site/index.njk
+++ b/site/index.njk
@@ -12,6 +12,7 @@ permalink: /index.html
 </section>
 
 {% set activeJobs = collections.jobs %}
+{% set chapterLeads = collections.chapters %}
 
 {% include "partials/filter-bar.njk" %}
 
@@ -29,6 +30,29 @@ permalink: /index.html
     {% endfor %}
   </div>
   <p id="no-results" class="no-results" style="display:none" aria-live="polite">No engineers match your filters. Try removing a filter or broadening your search.</p>
+</section>
+
+<section class="jobs-preview chapters-preview">
+  <div class="jobs-preview-header">
+    <div>
+      <p class="jobs-kicker">Chapter Leads</p>
+      <h2>GRC Engineering chapter leads</h2>
+      <p class="jobs-preview-copy">Meet the local leaders organizing GRC Engineering Club chapters — presidents, VPs, and founding teams building community city by city.</p>
+    </div>
+    <a href="/chapters/" class="btn btn-outline">Browse chapter leads</a>
+  </div>
+
+  {% if chapterLeads.length %}
+  <div class="card-grid chapters-preview-grid">
+    {% for chapter in chapterLeads %}
+      {% if loop.index0 < 3 %}
+        {% include "partials/chapter-card.njk" %}
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% else %}
+  <p class="jobs-preview-empty">Chapter lead listings are coming soon. See <a href="https://grcengclub.com/chapters" target="_blank" rel="noopener">grcengclub.com/chapters</a> to start or join a chapter.</p>
+  {% endif %}
 </section>
 
 <section class="jobs-preview">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a dedicated **Chapter Leads** section to the GRC Engineer Directory so local chapter leadership is discoverable alongside engineer profiles and jobs.

- New `chapters/` content collection (one markdown file per city) with a template and seeded leadership data from [grcengclub.com/chapters](https://grcengclub.com/chapters)
- `/chapters/` index with search/filter by status and region
- Per-chapter detail pages listing the leadership team, linking to directory profiles when a `github` is known
- Homepage preview section + nav/footer links

## Seeded chapters
19 chapters with known leads so far (DC, Austin, Atlanta, Raleigh, Nashville, Toronto, Chicago, Dallas, Boston, Seattle, LA, Philly, NYC, Bay Area, Hartford, Detroit Metro, Stockholm, Hyderabad, Nairobi). More cities can be added by copying `chapters/_template.md`.

## Screenshots
[Chapter leads index](https://cursor.com/agents/bc-e25d15e2-b0e5-5ed6-b768-1c9abb062f50/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fchapters-index.webp)
[Washington DC chapter detail](https://cursor.com/agents/bc-e25d15e2-b0e5-5ed6-b768-1c9abb062f50/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fchapter-detail-washington-dc.webp)
[Homepage chapter leads preview](https://cursor.com/agents/bc-e25d15e2-b0e5-5ed6-b768-1c9abb062f50/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhomepage-chapter-leads-preview.webp)

## Test plan
- [x] `npm run build` succeeds
- [x] `npm test` passes
- [x] `/chapters/` renders chapter cards in a grid with filters
- [x] Homepage preview shows the first three chapters
- [x] Chapter detail pages link to engineer profiles when `github` is set
- [ ] Spot-check remaining leads against live chapter pages on grcengclub.com and add missing cities

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://grc-engineering-club.slack.com/archives/C0ATC3NULTH/p1785724235071929?thread_ts=1785724235.071929&cid=C0ATC3NULTH)

<div><a href="https://cursor.com/agents/bc-e25d15e2-b0e5-5ed6-b768-1c9abb062f50?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e25d15e2-b0e5-5ed6-b768-1c9abb062f50&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Chapter Leads directory with profiles, locations, status, meeting details, leadership contacts, and external links.
  * Added searchable and filterable chapter listings by text, status, and region.
  * Added dedicated chapter detail pages with responsive layouts and accessible navigation.
  * Added chapter previews to the homepage and links throughout site navigation.
  * Added chapter pages for communities across North America, Europe, Africa, and Asia.
* **Documentation**
  * Added README guidance and a template for creating chapter listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->