### PR TITLE
fix: keep chapter filters visible

### DIFF
--- a/site/assets/js/filter-scroll.js
+++ b/site/assets/js/filter-scroll.js
@@ -7,6 +7,7 @@
   var backdrop = filters.querySelector("[data-filter-dismiss]");
   var toggleButtons = Array.from(filters.querySelectorAll("[data-filter-toggle]"));
   var shortcutLabels = Array.from(filters.querySelectorAll(".filter-shortcut"));
+  if (!toggleButtons.length) return;
   var manuallyCollapsed = true;
   var lastTrigger = null;
   var inertedElements = [];


### PR DESCRIPTION
## Summary
- prevent the global filter palette script from collapsing static filter panels that do not have a palette toggle
- preserve the existing collapsible search/filter palette on the engineer directory

## Validation
- `node --check site/assets/js/filter-scroll.js`
- `npm test` (14/14 passing)
- `npm run build` (268 files)
- browser smoke test: chapter search/status controls remain visible and functional; engineer directory palette remains collapsed behind its toggle

Follow-up to #122 after live deployment smoke testing exposed the integration bug.