### PR TITLE
feat: auto-sync chapters from the club site daily

### DIFF
--- a/.github/workflows/sync-chapters.yml
+++ b/.github/workflows/sync-chapters.yml
@@ -1,0 +1,43 @@
+name: Sync Chapters
+
+# Keeps chapters/*.md in step with the club site's source of truth
+# (src/content/chapters.json in ajy0127/grcengclub) so new provisional
+# chapters show up here without anyone hand-writing a file.
+#
+# Requires the GRCENGCLUB_READ_TOKEN secret: a fine-grained PAT with
+# read-only Contents access to ajy0127/grcengclub (it's a private repo).
+
+on:
+  schedule:
+    - cron: "0 14 * * *"
+  workflow_dispatch:
+
+jobs:
+  sync-chapters:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Fetch chapters.json from the club site repo
+        run: |
+          curl --fail --silent --show-error \
+            -H "Authorization: Bearer ${{ secrets.GRCENGCLUB_READ_TOKEN }}" \
+            -H "Accept: application/vnd.github.raw" \
+            -o /tmp/chapters.json \
+            "https://api.github.com/repos/ajy0127/grcengclub/contents/src/content/chapters.json?ref=main"
+
+      - name: Regenerate chapter files
+        run: node scripts/sync-chapters.js /tmp/chapters.json
+
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add chapters/
+          git diff --staged --quiet || git commit -m "data: auto-sync chapters from grcengclub.com"
+          git pull --rebase origin main
+          git push

--- a/scripts/sync-chapters.js
+++ b/scripts/sync-chapters.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// Regenerate chapters/*.md from the club site's chapters.json (the source of
+// truth behind grcengclub.com/chapters). One file per live chapter (leaders
+// present); chapter files whose slug is no longer live are removed so renames
+// (nairobi -> kenya) don't leave ghosts. _template.md is never touched.
+//
+// Usage: node scripts/sync-chapters.js path/to/chapters.json
+// The sync-chapters workflow downloads chapters.json and runs this daily.
+
+const fs = require("fs");
+const path = require("path");
+
+const REGION = {
+  "United States": "North America",
+  Canada: "North America",
+  Germany: "Europe",
+  Ireland: "Europe",
+  Sweden: "Europe",
+  "United Kingdom": "Europe",
+  Kenya: "Africa",
+  India: "Asia",
+  Qatar: "Asia",
+  Singapore: "Asia",
+  Australia: "Oceania",
+};
+
+// Refuse to run on implausibly small input: a truncated or broken download
+// must not mass-delete chapter pages.
+const MIN_LIVE_CHAPTERS = 15;
+
+function yamlStr(value) {
+  const needsQuote =
+    value.includes(": ") ||
+    value.endsWith(":") ||
+    value.includes("#") ||
+    "\"'&*?|>%@`[]{}!-".includes(value[0]);
+  if (needsQuote) {
+    return '"' + value.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+  }
+  return value;
+}
+
+function render(ch) {
+  const region = REGION[ch.country];
+  if (!region) {
+    throw new Error(
+      `No region mapping for country "${ch.country}" (${ch.slug}) - add it to REGION in scripts/sync-chapters.js`,
+    );
+  }
+  const lines = [
+    "---",
+    `city: ${yamlStr(ch.city)}`,
+    `slug: ${ch.slug}`,
+    `status: ${ch.status}`,
+    `country: ${yamlStr(ch.country)}`,
+    `region: ${region}`,
+    `chapter_url: https://grcengclub.com/chapters/${ch.slug}`,
+    `meetings: ${yamlStr(ch.meetingCadence || "Meeting schedule coming soon")}`,
+    `summary: ${yamlStr(ch.blurb)}`,
+    "leads:",
+  ];
+  for (const lead of ch.leaders) {
+    lines.push(`  - name: ${yamlStr(lead.name)}`);
+    lines.push(`    role: ${yamlStr(lead.role)}`);
+    if (lead.linkedin) lines.push(`    linkedin: ${lead.linkedin}`);
+  }
+  lines.push("---", "");
+  return lines.join("\n");
+}
+
+function main() {
+  const src = process.argv[2];
+  if (!src) {
+    console.error("Usage: node scripts/sync-chapters.js path/to/chapters.json");
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(src, "utf8"));
+  const live = data.chapters.filter((c) => c.leaders && c.leaders.length > 0);
+  if (live.length < MIN_LIVE_CHAPTERS) {
+    console.error(
+      `Only ${live.length} live chapters in ${src} - refusing to sync (guard is ${MIN_LIVE_CHAPTERS}).`,
+    );
+    process.exit(1);
+  }
+
+  const chaptersDir = path.join(__dirname, "..", "chapters");
+  const liveSlugs = new Set(live.map((c) => c.slug));
+
+  let wrote = 0;
+  for (const ch of live) {
+    fs.writeFileSync(path.join(chaptersDir, `${ch.slug}.md`), render(ch));
+    wrote += 1;
+  }
+
+  let removed = 0;
+  for (const file of fs.readdirSync(chaptersDir)) {
+    if (!file.endsWith(".md") || file.startsWith("_")) continue;
+    const slug = file.slice(0, -3);
+    if (!liveSlugs.has(slug)) {
+      fs.unlinkSync(path.join(chaptersDir, file));
+      console.log(`removed stale chapter: ${file}`);
+      removed += 1;
+    }
+  }
+
+  console.log(`synced ${wrote} chapters, removed ${removed}`);
+}
+
+main();


### PR DESCRIPTION
Follow-up to #131. The chapter list drifted within hours of launching because chapter activations happen in ajy0127/grcengclub, not here - so this makes the sync automatic.

## How it works
- Daily cron (plus manual dispatch) fetches `src/content/chapters.json` from ajy0127/grcengclub, runs `scripts/sync-chapters.js`, and bot-commits to main only when something changed (same pattern as update-readme).
- One markdown file per live chapter; files whose slug is no longer live are removed, so renames like nairobi -> kenya clean up after themselves.
- Safety guard: refuses to run if the source has fewer than 15 live chapters, so a truncated download can't mass-delete pages.

## Verified locally
- Run against current chapters.json: `synced 44 chapters, removed 0` and a clean git diff (idempotent against #131)
- Truncated input: refused, exit 1, no files touched
- Planted ghost chapter: removed
- Repo tests still 14/14

## ⚠️ One manual step before it works
The source repo is **private**, so the workflow needs a secret named `GRCENGCLUB_READ_TOKEN`: a fine-grained PAT with read-only **Contents** access to ajy0127/grcengclub, added under Settings → Secrets → Actions in this repo. Until that exists, the workflow fails at the fetch step (loudly, changing nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)