### PR TITLE
fix(chapters): add mobile filter command palette

### DIFF
--- a/site/_includes/partials/chapter-filter-bar.njk
+++ b/site/_includes/partials/chapter-filter-bar.njk
@@ -1,16 +1,36 @@
 <aside class="filters" id="chapter-filters" aria-label="Filter chapter leads">
-  <div class="filters-expanded-panel">
+  <div class="filters-compact-bar">
+    <span class="filter-compact-label"><strong data-compact-results>{{ collections.chapters.length }}</strong> chapters</span>
+    <button class="filter-toggle filter-command-trigger" type="button" data-filter-toggle aria-expanded="false" aria-controls="filter-panel">
+      <span>Search &amp; filter</span>
+      <kbd class="filter-shortcut" aria-hidden="true">⌘K</kbd>
+    </button>
+  </div>
+
+  <button class="filter-palette-backdrop" type="button" data-filter-dismiss tabindex="-1" aria-hidden="true" aria-label="Close search and filters"></button>
+
+  <div class="filters-expanded-panel" id="filter-panel">
     <div class="controls-header">
-      <p class="results-count" aria-live="polite" aria-atomic="true">
-        <span id="result-count">{{ collections.chapters.length }}</span> of {{ collections.chapters.length }} chapters
-      </p>
+      <div class="filter-palette-heading">
+        <p class="filter-palette-title">Search chapter leads</p>
+        <p class="results-count" aria-live="polite" aria-atomic="true">
+          <span id="result-count">{{ collections.chapters.length }}</span> of {{ collections.chapters.length }} chapters
+        </p>
+      </div>
+      <div class="controls-actions">
+        <div class="controls-meta" aria-label="Chapter directory coverage">
+          <span>{{ collections.chapters | uniqueValues("region") | length }} regions</span>
+          <span>{{ collections.chapters | uniqueValues("country") | length }} countries</span>
+        </div>
+        <button class="filter-toggle filter-palette-close" type="button" data-filter-toggle aria-expanded="true" aria-controls="filter-panel" aria-label="Close chapter search and filters">Close</button>
+      </div>
     </div>
 
-    <div class="controls-bar">
+    <div class="controls-bar chapter-controls-bar">
       <div class="search-box">
         <input
           type="search"
-          id="chapter-search-input"
+          id="search-input"
           placeholder="Search by city, lead name, or role..."
           aria-label="Search chapter leads"
           autocomplete="off"

--- a/site/assets/js/chapters-search.js
+++ b/site/assets/js/chapters-search.js
@@ -1,8 +1,9 @@
 (function () {
   var filterRoot = document.getElementById("chapter-filters");
-  var searchInput = document.getElementById("chapter-search-input");
+  var searchInput = document.getElementById("search-input");
   var cardGrid = document.querySelector(".chapters-directory .card-grid");
   var resultCount = document.getElementById("result-count");
+  var compactResultCount = filterRoot ? filterRoot.querySelector("[data-compact-results]") : null;
   var noResults = document.getElementById("no-results");
   if (!filterRoot || !cardGrid) return;
 
@@ -49,6 +50,7 @@
     });
 
     if (resultCount) resultCount.textContent = String(visible);
+    if (compactResultCount) compactResultCount.textContent = String(visible);
     if (noResults) noResults.style.display = visible ? "none" : "block";
   }
 

--- a/tests/chapters-filter-palette.test.js
+++ b/tests/chapters-filter-palette.test.js
@@ -1,0 +1,30 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const projectRoot = path.resolve(__dirname, "..");
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), "utf8");
+}
+
+test("chapter filters expose the progressive command-palette controls", () => {
+  const partial = read("site/_includes/partials/chapter-filter-bar.njk");
+  const page = read("site/chapters.njk");
+
+  assert.match(partial, /class="filters-compact-bar"/);
+  assert.match(partial, /class="[^"]*filter-command-trigger[^"]*"[^>]*data-filter-toggle/);
+  assert.match(partial, /class="filter-shortcut"/);
+  assert.match(partial, /data-filter-dismiss/);
+  assert.match(partial, /id="filter-panel"/);
+  assert.match(partial, /class="[^"]*filter-palette-close[^"]*"[^>]*data-filter-toggle/);
+  assert.match(page, /assets\/js\/filter-scroll\.js/);
+});
+
+test("chapter search binds to the shared palette input and compact result count", () => {
+  const script = read("site/assets/js/chapters-search.js");
+
+  assert.match(script, /getElementById\("search-input"\)/);
+  assert.match(script, /querySelector\("\[data-compact-results\]"\)/);
+});


### PR DESCRIPTION
## Summary
- gives chapter filters the same compact command-palette trigger as the engineer directory
- supports Cmd/Ctrl+K, Escape, backdrop dismissal, focus management, and responsive mobile tabs
- keeps the compact chapter count synchronized after search/filter changes
- adds regression coverage for the palette contract

## Validation
- `npm test` (16/16 pass)
- `npm run build`
- `node --check site/assets/js/chapters-search.js`
- `node --check site/assets/js/filter-scroll.js`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a compact chapter search and filter control with a keyboard shortcut.
  - Added visible chapter result counts, region and country coverage counts, and a clear close option.
  - Added a dismissible backdrop for the expanded filter panel.

- **Bug Fixes**
  - Improved chapter filter interactions and search behavior across the chapter page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->