### PR TITLE
fix(chapters): remove empty mobile filter header

### DIFF
--- a/site/_includes/partials/chapter-filter-bar.njk
+++ b/site/_includes/partials/chapter-filter-bar.njk
@@ -39,10 +39,6 @@
     </div>
 
     <div class="filter-workbench">
-      <div class="filter-workbench-header">
-        <span>Filter by</span>
-      </div>
-
       <div class="filter-groups">
         <div class="filter-group open" data-group="status">
           <button type="button" class="filter-group-header" aria-expanded="true">

--- a/tests/chapters-filter-palette.test.js
+++ b/tests/chapters-filter-palette.test.js
@@ -28,3 +28,9 @@ test("chapter search binds to the shared palette input and compact result count"
   assert.match(script, /getElementById\("search-input"\)/);
   assert.match(script, /querySelector\("\[data-compact-results\]"\)/);
 });
+
+test("chapter filters avoid an empty mobile workbench header", () => {
+  const partial = read("site/_includes/partials/chapter-filter-bar.njk");
+
+  assert.doesNotMatch(partial, /class="filter-workbench-header"/);
+});


### PR DESCRIPTION
## Summary
- removes the empty workbench strip exposed by the mobile chapter palette
- adds a regression assertion for the mobile layout contract

## Validation
- `npm test` (17/17 pass)
- `npm run build`
- 390x844 Playwright smoke test