### PR TITLE
Fix profile updates to use owner-authored PRs

### DIFF
--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -6,8 +6,10 @@ on:
 
 jobs:
   process:
-    # Trigger on issues that look like profile submissions
-    if: startsWith(github.event.issue.title, 'New Profile:')
+    # New submissions create automated PRs; update issues redirect owners to GitHub editing.
+    if: >-
+      startsWith(github.event.issue.title, 'New Profile:') ||
+      startsWith(github.event.issue.title, 'Update Profile:')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -15,11 +17,86 @@ jobs:
       issues: write
     steps:
       - name: Process submission and create PR
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const issue = context.payload.issue;
             const body = issue.body || '';
+            const isUpdateSubmission = issue.title.startsWith('Update Profile:');
+
+            async function findExistingProfileByGithub(targetUsername) {
+              const entries = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: 'engineers',
+                ref: 'main'
+              });
+
+              for (const entry of entries.data) {
+                if (entry.type !== 'file' || !entry.name.endsWith('.md') || entry.name === '_template.md') {
+                  continue;
+                }
+
+                const file = await github.rest.repos.getContent({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  path: entry.path,
+                  ref: 'main'
+                });
+
+                const fileContent = Buffer.from(file.data.content, 'base64').toString('utf8');
+                const fileGithubMatch = fileContent.match(/^github:\s*"?(.*?)"?$/m);
+                if (!fileGithubMatch) continue;
+
+                if (fileGithubMatch[1].trim().toLowerCase() === targetUsername) {
+                  return entry.path;
+                }
+              }
+
+              return null;
+            }
+
+            if (isUpdateSubmission) {
+              const username = issue.title.slice('Update Profile:'.length).trim();
+              const normalizedUsername = username.toLowerCase();
+              const validUsername = /^(?!.*--)[a-z0-9](?:[a-z0-9-]{0,37}[a-z0-9])?$/.test(normalizedUsername);
+              const existingProfilePath = validUsername
+                ? await findExistingProfileByGithub(normalizedUsername)
+                : null;
+
+              if (existingProfilePath) {
+                const editUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/edit/main/${existingProfilePath}`;
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: `⚠️ Update your profile on GitHub so the change is authenticated to your account and submitted as your pull request: ${editUrl}`
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  state: 'closed',
+                  state_reason: 'completed'
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `⚠️ No existing profile was found for **@${username || 'unknown'}**. Use the [new-profile submission form](https://directory.grcengclub.com/submit/) instead.`
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
+              return;
+            }
 
             function parseSubmissionBody(issueBody) {
               const encodedMatch = issueBody.match(
@@ -142,45 +219,14 @@ jobs:
               // Label may not exist yet — not critical
             }
 
-            async function findExistingProfileByGithub() {
-              const entries = await github.rest.repos.getContent({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: 'engineers',
-                ref: 'main'
-              });
-
-              for (const entry of entries.data) {
-                if (entry.type !== 'file' || !entry.name.endsWith('.md') || entry.name === '_template.md') {
-                  continue;
-                }
-
-                const file = await github.rest.repos.getContent({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  path: entry.path,
-                  ref: 'main'
-                });
-
-                const fileContent = Buffer.from(file.data.content, 'base64').toString('utf8');
-                const fileGithubMatch = fileContent.match(/^github:\s*"?(.*?)"?$/m);
-                if (!fileGithubMatch) continue;
-
-                if (fileGithubMatch[1].trim().toLowerCase() === normalizedUsername) {
-                  return entry.path;
-                }
-              }
-
-              return null;
-            }
-
-            const existingProfilePath = await findExistingProfileByGithub();
+            const existingProfilePath = await findExistingProfileByGithub(normalizedUsername);
             if (existingProfilePath) {
+              const editUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/edit/main/${existingProfilePath}`;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                body: `⚠️ A profile for **@${username}** already exists at \`${existingProfilePath}\`. If you'd like to update it, please open a pull request editing that file directly.`
+                body: `⚠️ A profile for **@${username}** already exists at \`${existingProfilePath}\`. Update your profile on GitHub so the change is authenticated to your account and submitted as your pull request: ${editUrl}`
               });
               await github.rest.issues.update({
                 owner: context.repo.owner,

--- a/site/_includes/layouts/profile.njk
+++ b/site/_includes/layouts/profile.njk
@@ -132,6 +132,7 @@ layout: layouts/base.njk
 
       <div class="profile-side-card">
         <h2>Contact</h2>
+        <p class="profile-side-text">Sign in to GitHub to edit this profile and submit the change as your pull request.</p>
         <div class="profile-cta-links">
           {% for social in socials %}
             {% set val = socialData[social.key] %}
@@ -146,6 +147,7 @@ layout: layouts/base.njk
               {% endif %}
             {% endif %}
           {% endfor %}
+          <a href="https://github.com/GRCEngClub/directory/edit/main/engineers/{{ github }}.md" class="btn btn-outline" target="_blank" rel="noopener">Edit your profile on GitHub</a>
         </div>
         <button class="profile-share-btn" id="share-btn"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 12v8a2 2 0 002 2h12a2 2 0 002-2v-8"/><polyline points="16 6 12 2 8 6"/><line x1="12" y1="2" x2="12" y2="15"/></svg><span>Share this profile</span></button>
         <span class="share-status" id="share-status" aria-live="polite"></span>

--- a/site/submit.njk
+++ b/site/submit.njk
@@ -9,6 +9,7 @@ permalink: /submit/index.html
   <div class="submit-header">
     <h1>Join the Directory</h1>
     <p class="submit-tagline">Fill out your profile below. When you're ready, we'll copy your profile payload and open a GitHub submission issue for you. After you submit the issue, maintainers review the generated pull request before your profile goes live.</p>
+    <p class="submit-hint"><strong>Already in the directory?</strong> Open your profile and select <strong>Edit your profile on GitHub</strong>. Updates are submitted directly through GitHub so the pull request is authenticated to your account.</p>
   </div>
 
   <div class="step-indicator">

--- a/tests/profile-update-flow.test.js
+++ b/tests/profile-update-flow.test.js
@@ -1,0 +1,131 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+function source(relativePath) {
+  return fs.readFileSync(path.join(__dirname, '..', relativePath), 'utf8');
+}
+
+function workflowScript() {
+  const workflow = source('.github/workflows/process-submission.yml');
+  const marker = '          script: |\n';
+  const start = workflow.indexOf(marker);
+  assert.notEqual(start, -1, 'workflow script block must exist');
+  return workflow
+    .slice(start + marker.length)
+    .split('\n')
+    .map(function (line) {
+      return line.startsWith('            ') ? line.slice(12) : line;
+    })
+    .join('\n');
+}
+
+async function runWorkflow(issue, github) {
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+  const execute = new AsyncFunction('github', 'context', workflowScript());
+  await execute(github, {
+    payload: { issue },
+    repo: { owner: 'GRCEngClub', repo: 'directory' }
+  });
+}
+
+test('update issues are redirected to the authenticated GitHub edit flow', function () {
+  const workflow = source('.github/workflows/process-submission.yml');
+  const redirectIndex = workflow.indexOf('Update your profile on GitHub');
+  const updateHandlerIndex = workflow.indexOf('if (isUpdateSubmission)');
+  const payloadParsingIndex = workflow.indexOf('let content;');
+  const branchIndex = workflow.indexOf('// --- Create branch ---');
+
+  assert.match(
+    workflow,
+    /startsWith\(github\.event\.issue\.title, 'Update Profile:'\)/
+  );
+  assert.match(
+    workflow,
+    /https:\/\/github\.com\/\$\{context\.repo\.owner\}\/\$\{context\.repo\.repo\}\/edit\/main\/\$\{existingProfilePath\}/
+  );
+  assert.ok(redirectIndex > -1, 'workflow must explain that updates happen on GitHub');
+  assert.ok(
+    updateHandlerIndex > -1 && updateHandlerIndex < payloadParsingIndex,
+    'update issues must be routed before issue payload parsing'
+  );
+  assert.ok(redirectIndex < branchIndex, 'update redirect must happen before branch creation');
+});
+
+test('malformed update issue is closed with the exact GitHub edit link and no repository mutation', async function () {
+  const comments = [];
+  const updates = [];
+  const github = {
+    rest: {
+      repos: {
+        async getContent(options) {
+          if (options.path === 'engineers') {
+            return {
+              data: [
+                { type: 'file', name: 'itsrubenclarke.md', path: 'engineers/itsrubenclarke.md' }
+              ]
+            };
+          }
+          assert.equal(options.path, 'engineers/itsrubenclarke.md');
+          return {
+            data: {
+              content: Buffer.from('github: "itsrubenclarke"\n').toString('base64')
+            }
+          };
+        }
+      },
+      issues: {
+        async createComment(options) {
+          comments.push(options.body);
+        },
+        async update(options) {
+          updates.push(options);
+        }
+      },
+      git: new Proxy({}, {
+        get() {
+          throw new Error('update issue reached Git branch mutation');
+        }
+      }),
+      pulls: new Proxy({}, {
+        get() {
+          throw new Error('update issue reached pull-request creation');
+        }
+      })
+    }
+  };
+
+  await runWorkflow(
+    { number: 130, title: 'Update Profile: itsrubenclarke', body: '' },
+    github
+  );
+
+  assert.deepEqual(comments, [
+    '⚠️ Update your profile on GitHub so the change is authenticated to your account and submitted as your pull request: https://github.com/GRCEngClub/directory/edit/main/engineers/itsrubenclarke.md'
+  ]);
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].state, 'closed');
+  assert.equal(updates[0].state_reason, 'completed');
+});
+
+test('profile pages expose an exact GitHub edit link', function () {
+  const profile = source('site/_includes/layouts/profile.njk');
+
+  assert.match(
+    profile,
+    /https:\/\/github\.com\/GRCEngClub\/directory\/edit\/main\/engineers\/\{\{ github \}\}\.md/
+  );
+  assert.match(profile, />Edit your profile on GitHub</);
+  assert.match(
+    profile,
+    /Sign in to GitHub to edit this profile and submit the change as your pull request\./
+  );
+});
+
+test('submission form states that existing profiles are updated on GitHub', function () {
+  const submit = source('site/submit.njk');
+
+  assert.match(submit, /Already in the directory\?/);
+  assert.match(submit, /Updates are submitted directly through GitHub/);
+});


### PR DESCRIPTION
## Summary
- keep the web submission form limited to new profiles
- route `Update Profile:` issues to the profile owner's exact authenticated GitHub edit URL before parsing issue payloads
- add an **Edit your profile on GitHub** action and ownership guidance to profile pages
- pin `actions/github-script` to the reviewed v9 commit SHA

## Security model
Existing profile changes are never written from web-form issue payloads. GitHub authentication and the fork/edit flow ensure the profile owner authors the pull request.

## Verification
- `npm test` — 21/21 passed
- `npm run build` — passed
- workflow YAML parse — passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- mocked issue #130 regression test confirms no branch/file/PR APIs are called
- independent fail-closed review — passed

Addresses the update-flow problem exposed by #130 without treating the requested profile edit as completed.