### PR TITLE
fix: harden profile submission automations

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -11,8 +11,10 @@ on:
       - '.eleventy.js'
       - 'package.json'
       - 'package-lock.json'
+  # Pushes made with GITHUB_TOKEN don't fire the push trigger above, so
+  # workflows that commit site content need to be listed here explicitly.
   workflow_run:
-    workflows: ['Import Jobs']
+    workflows: ['Import Jobs', 'Sync Chapters']
     types: [completed]
   workflow_dispatch:
 

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -3,11 +3,19 @@ name: Process Profile Submission
 on:
   issues:
     types: [opened, reopened]
+  # Manual retry path: if a run fails (e.g. runner outage) the issue stays open
+  # and never re-triggers, so let maintainers reprocess it by issue number.
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number of the profile submission to (re)process"
+        required: true
+        type: number
 
 jobs:
   process:
     # Trigger only on new profile submissions. Updates must be owner-authored PRs.
-    if: startsWith(github.event.issue.title, 'New Profile:')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.issue.title, 'New Profile:')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,8 +26,41 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
-            const issue = context.payload.issue;
+            let issue = context.payload.issue;
+            if (!issue) {
+              const issueNumber = Number(context.payload.inputs && context.payload.inputs.issue_number);
+              if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+                core.setFailed('workflow_dispatch requires a valid issue_number input.');
+                return;
+              }
+              const response = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber
+              });
+              issue = response.data;
+              if (!issue.title.startsWith('New Profile:')) {
+                core.setFailed(`Issue #${issueNumber} is not a profile submission (title must start with "New Profile:").`);
+                return;
+              }
+            }
             const body = issue.body || '';
+
+            async function rejectSubmission(message) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: message
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
+            }
 
             async function findExistingProfileByGithub(targetUsername) {
               const entries = await github.rest.repos.getContent({
@@ -80,62 +121,49 @@ jobs:
             try {
               content = parseSubmissionBody(body);
             } catch (error) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: '❌ We could not decode the submission payload in this issue. Please return to the [submission form](https://directory.grcengclub.com/submit/), copy a fresh payload, and submit a new issue.'
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'not_planned'
-              });
+              await rejectSubmission('❌ We could not decode the submission payload in this issue. Please return to the [submission form](https://directory.grcengclub.com/submit/), copy a fresh payload, and submit a new issue.');
               return;
             }
 
             if (!content) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: '❌ Could not find a valid submission payload in this issue. Please return to the [submission form](https://directory.grcengclub.com/submit/), paste the copied payload into the issue body, and submit a new issue.'
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'not_planned'
-              });
+              await rejectSubmission('❌ Could not find a valid submission payload in this issue. Please return to the [submission form](https://directory.grcengclub.com/submit/), paste the copied payload into the issue body, and submit a new issue.');
               return;
             }
 
             // --- Parse required fields from YAML frontmatter ---
             const ghMatch = content.match(/^github:\s*"([^"]+)"/m);
             if (!ghMatch) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: '❌ Could not find a valid `github` username in the profile. Please resubmit using the [submission form](https://directory.grcengclub.com/submit/).'
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'not_planned'
-              });
+              await rejectSubmission('❌ Could not find a valid `github` username in the profile. Please resubmit using the [submission form](https://directory.grcengclub.com/submit/).');
               return;
             }
             const username = ghMatch[1].trim();
             const normalizedUsername = username.toLowerCase();
 
+            // The username becomes a file path and must satisfy the same rule
+            // the validation workflow enforces.
+            if (!/^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(username)) {
+              await rejectSubmission(`❌ \`${username}\` is not a valid GitHub username (1-39 alphanumeric characters or hyphens, no leading/trailing hyphen). Please resubmit using the [submission form](https://directory.grcengclub.com/submit/).`);
+              return;
+            }
+
             const nameMatch = content.match(/^name:\s*"([^"]+)"/m);
-            const profileName = nameMatch ? nameMatch[1] : username;
+            if (!nameMatch) {
+              await rejectSubmission('❌ Could not find a valid `name` in the profile. Please resubmit using the [submission form](https://directory.grcengclub.com/submit/).');
+              return;
+            }
+            const profileName = nameMatch[1];
+
+            // Mirror the checks in validate-submission.yml so PRs opened by this
+            // workflow are sound even before their CI runs are approved.
+            if (!/^specializations:\s*\n(?:[ \t]+-[ \t]+.+\n?)+/m.test(content)) {
+              await rejectSubmission('❌ The profile must list at least one specialization. Please resubmit using the [submission form](https://directory.grcengclub.com/submit/).');
+              return;
+            }
+
+            if (/<script|<iframe|<embed|<object|onerror=|onload=|onclick=|onmouseover=|javascript:/i.test(content)) {
+              await rejectSubmission('❌ The submission contains HTML that is not allowed in profiles. Please remove any embedded HTML and resubmit using the [submission form](https://directory.grcengclub.com/submit/).');
+              return;
+            }
 
             // --- Reject placeholder/template submissions ---
             const placeholders = [
@@ -144,23 +172,13 @@ jobs:
               'YOUR-GITHUB-USERNAME',
             ];
             if (placeholders.includes(username) || placeholders.includes(profileName)) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body: '❌ This submission still contains placeholder values from the template. Please fill in your actual name and GitHub username, then resubmit using the [submission form](https://directory.grcengclub.com/submit/).'
-              });
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                state: 'closed',
-                state_reason: 'not_planned'
-              });
+              await rejectSubmission('❌ This submission still contains placeholder values from the template. Please fill in your actual name and GitHub username, then resubmit using the [submission form](https://directory.grcengclub.com/submit/).');
               return;
             }
 
-            const filename = `engineers/${normalizedUsername}.md`;
+            // Filename must match the frontmatter `github` value exactly —
+            // validate-submission.yml rejects any casing mismatch.
+            const filename = `engineers/${username}.md`;
 
             // --- Label the issue for bookkeeping ---
             try {
@@ -210,17 +228,15 @@ jobs:
               });
             } catch (e) {
               if (e.status === 422) {
-                // Branch already exists — delete and recreate
-                await github.rest.git.deleteRef({
+                // Branch already exists (e.g. an earlier run died midway) —
+                // reset it to main. Deleting it instead would auto-close any
+                // open PR attached to the branch.
+                await github.rest.git.updateRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  ref: `heads/${branchName}`
-                });
-                await github.rest.git.createRef({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: `refs/heads/${branchName}`,
-                  sha: mainRef.data.object.sha
+                  ref: `heads/${branchName}`,
+                  sha: mainRef.data.object.sha,
+                  force: true
                 });
               } else {
                 throw e;
@@ -237,22 +253,36 @@ jobs:
               branch: branchName
             });
 
-            // --- Open PR ---
-            const pr = await github.rest.pulls.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: `Add profile: ${profileName} (@${username})`,
-              head: branchName,
-              base: 'main',
-              body: `Automated PR from #${issue.number}\n\nAdds engineer directory profile for @${username}.`
-            });
+            // --- Open PR (reuse the existing one when reprocessing) ---
+            let pr;
+            try {
+              const created = await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: `Add profile: ${profileName} (@${username})`,
+                head: branchName,
+                base: 'main',
+                body: `Automated PR from #${issue.number}\n\nAdds engineer directory profile for @${username}.`
+              });
+              pr = created.data;
+            } catch (e) {
+              if (e.status !== 422) throw e;
+              const existing = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${branchName}`,
+                state: 'open'
+              });
+              if (existing.data.length === 0) throw e;
+              pr = existing.data[0];
+            }
 
             // --- Comment with PR link and close issue ---
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              body: `✅ Your profile PR has been created: ${pr.data.html_url}\n\nA maintainer will review and merge it shortly!`
+              body: `✅ Your profile PR has been created: ${pr.html_url}\n\nA maintainer will review and merge it shortly!`
             });
 
             await github.rest.issues.update({

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -9,6 +9,12 @@ on:
       - '!engineers/_template.md'
   workflow_dispatch:
 
+# Serialize runs: concurrent pushes to main race each other on `git push`
+# and the loser fails.
+concurrency:
+  group: update-readme
+  cancel-in-progress: false
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest
@@ -21,7 +27,7 @@ jobs:
 
       - name: Install yq
         run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64
           sudo chmod +x /usr/local/bin/yq
 
       - name: Generate engineer table

--- a/site/_includes/layouts/profile.njk
+++ b/site/_includes/layouts/profile.njk
@@ -109,7 +109,11 @@ layout: layouts/base.njk
         <div class="project-list">
           {% for p in projects %}
           <div class="project-card">
+            {% if p.url %}
             <a href="{{ p.url }}" target="_blank" rel="noopener" class="project-name" aria-label="{{ p.name }} (opens in new tab)">{{ p.name }} <span class="external-icon" aria-hidden="true">↗</span></a>
+            {% else %}
+            <span class="project-name">{{ p.name }}</span>
+            {% endif %}
             {% if p.description %}<p class="project-desc">{{ p.description }}</p>{% endif %}
           </div>
           {% endfor %}

--- a/site/assets/js/submit.js
+++ b/site/assets/js/submit.js
@@ -54,6 +54,12 @@
     return (value || '').trim();
   }
 
+  // Users often paste highlights that already start with "- ", "* ", or "• ";
+  // strip those so the generator's own "- " prefix doesn't double up.
+  function stripLeadingBullet(line) {
+    return line.replace(/^[-*•]+\s+/, '');
+  }
+
   function showStep(n) {
     $$('.form-step').forEach(function (el) {
       el.hidden = Number(el.dataset.step) !== n;
@@ -560,7 +566,7 @@
       lines.push('## Experience Highlights');
       lines.push('');
       data.highlights.split('\n').forEach(function (line) {
-        var trimmed = line.trim();
+        var trimmed = stripLeadingBullet(line.trim());
         if (trimmed) lines.push('- ' + trimmed);
       });
       lines.push('');
@@ -698,7 +704,7 @@
     if (data.highlights) {
       html += '<div class="profile-body"><h2>Experience Highlights</h2><ul>';
       data.highlights.split('\n').forEach(function (line) {
-        var trimmed = line.trim();
+        var trimmed = stripLeadingBullet(line.trim());
         if (trimmed) html += '<li>' + escHtml(trimmed) + '</li>';
       });
       html += '</ul></div>';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes several automation issues surfaced while reviewing the open PRs (#136, #138, #140, #142, #144) and the recent workflow runs.

### Submission form (`site/assets/js/submit.js`)
- Highlights that users type with a leading `- `, `* `, or `• ` no longer get a second list marker prepended. This is the bug that produced the `- - Leads 10+ SOC 1...` lines in #142 (fixed on that branch separately). Applies to both the generated markdown and the live preview.

### Profile submission workflow (`.github/workflows/process-submission.yml`)
- Added a `workflow_dispatch` trigger with an `issue_number` input so a submission can be reprocessed when a run dies. The Aug 6 run for issue #145 was cancelled by a GitHub runner outage ("job was not acquired by Runner"), and because the issue stayed open there was no way to re-trigger processing.
- The retry path is idempotent: an existing `profile/<username>` branch is force-reset via `updateRef` instead of delete-and-recreate (deleting a branch auto-closes its open PR), and an existing open PR for the branch is reused instead of failing on create.
- Submissions are now validated inline before a branch/PR is created, mirroring `validate-submission.yml`: `name` required, non-empty `specializations`, dangerous-HTML rejection, and GitHub username format. The username check also prevents path-traversal values from reaching the file path. This matters because validate runs on bot-created PRs currently sit in "action required" (never execute) unless a maintainer approves them.
- The profile filename now uses the exact `github` value instead of a lowercased copy, so the filename always matches the frontmatter field as `validate-submission.yml` requires (the web form lowercases usernames, but hand-crafted payloads could previously produce a mismatched, always-failing PR).

### Deploy workflow (`.github/workflows/deploy-site.yml`)
- Added `Sync Chapters` to the `workflow_run` triggers. Its pushes to `main` use `GITHUB_TOKEN` and therefore never fire the `push` trigger, so synced chapter changes were never deployed until some unrelated deploy happened. Import Jobs already had this wiring; Sync Chapters was missed.

### README workflow (`.github/workflows/update-readme.yml`)
- Added a `concurrency` group. Two runs raced on Aug 5 (15:01:01 and 15:01:05 UTC) and the loser failed at `git push`.
- Pinned yq to v4.44.1 to match `validate-submission.yml` instead of pulling `latest`.

### Site rendering (`site/_includes/layouts/profile.njk`)
- Projects without a `url` (allowed by the submission form, present in #140) rendered as `<a href="">` with an "opens in new tab" arrow. They now render as plain text.

## Testing
- `npm run build` passes; verified project rendering output for a profile with URL-less projects.
- Workflow YAML parses; the inline `github-script` body passes `node --check`.
- New validation regexes tested against the five open PR profiles and issue #145's payload (all pass) plus adversarial inputs (`../evil` username, empty specializations — both rejected).

## Notes for maintainers
- Validate runs for #136, #140, #142, #144 are queued as "action required" and need approval in the Actions tab (or a change to the repo's Actions approval policy) before checks appear on those PRs. All four profiles pass the validation rules when run locally.
- The Aug 6 Sync Chapters failure was the same runner outage, not a workflow bug; the next scheduled run should succeed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdc06-eede-71f3-85d5-626a0223056b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdc06-eede-71f3-85d5-626a0223056b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added manual reprocessing for submissions by issue number.
  - Existing open pull requests are reused when duplicate submissions are reprocessed.

- **Bug Fixes**
  - Improved submission validation for usernames, names, specializations, HTML, and filename casing.
  - Projects without links now display as plain text.
  - Experience highlights no longer show duplicate bullet markers.

- **Reliability**
  - Deployment and README updates run more consistently, reducing missed or overlapping updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->