### PR TITLE
Revise John Flack's profile details and projects

### DIFF
--- a/engineers/jtflack-grc.md
+++ b/engineers/jtflack-grc.md
@@ -1,27 +1,32 @@
 ---
 name: "John Flack"
 github: "jtflack-grc"
+title: "Systems & Security Engineer"
+location: "High Point, NC"
+linkedin: "https://www.linkedin.com/in/john-flack"
+portfolio: "https://jtflack-grc.github.io/portfolio/"
+
 specializations:
   - "Audit & Assurance"
-  - "Cloud Security"
-  - "Compliance Automation"
-  - "Risk Management"
-  - "Security Architecture"
   - "Security Governance"
+  - "Risk Management"
+  - "Compliance Automation"
+  - "Control Evidence Engineering"
+  - "Legacy Systems Governance"
+  - "Security Architecture"
   - "Third-Party Risk"
   - "Vulnerability Management"
   - "AI Governance"
+  - "Cyber Risk Quantification"
+  - "Cloud Security"
   - "IBM i"
   - "AIX"
   - "Solaris 11"
   - "Linux"
-  - "VMWare"
+  - "VMware"
   - "COBOL"
   - "Financial Modeling"
-title: "System Engineer"
-location: "High Point, NC"
-linkedin: "https://www.linkedin.com/in/john-flack"
-portfolio: "https://jtflack-grc.github.io/portfolio/"
+
 frameworks:
   - "COBIT"
   - "CSA STAR"
@@ -33,71 +38,186 @@ frameworks:
   - "ISO 42001"
   - "NIST AI RMF"
   - "NIST RMF"
-  - "PCI-DSS"
+  - "PCI DSS"
   - "SOC 2"
+
 languages:
   - "Bash"
   - "PowerShell"
   - "Python"
   - "SQL"
   - "Terraform"
-  - "RPG (AS/400)"
+  - "RPG (IBM i / AS/400)"
+
 certifications:
-  - "CySA+"
-  - "TAISE"
-  - "GRCP"
-  - "GRCA"
-  - "Security+"
-  - "ISC2 CC"
-  - "FAIR"
-  - "ISO 27001 Lead Auditor"
-  - "ISO 42001 Lead Auditor"
-  - "FAIR-TPRM"
+  - "CompTIA CySA+"
+  - "CompTIA Security+"
+  - "GIAC Foundational Cybersecurity Technologies (GFACT)"
+  - "CSA Certificate of Cloud Security Knowledge (CCSK)"
+  - "CSA Certificate of Competence in Zero Trust (CCZT)"
+  - "Trusted AI Safety Expert (TAISE)"
+  - "OCEG GRCP"
+  - "OCEG GRCA"
+  - "ISO/IEC 27001 Lead Auditor"
+  - "ISO/IEC 42001 Lead Auditor"
+  - "ISO 31000 Foundations"
+  - "NIST AI Risk Management Framework"
+  - "FAIR Foundations"
+  - "FAIR Cyber Risk Analysis"
+  - "FAIR Third-Party Risk Management"
+  - "GRC Engineering Club CGE-AUD"
+  - "GRC Engineering Club CGE-P"
   - "FMVA"
-  - "CCSK"
-  - "CCZT"
+  - "ISC2 CC"
   - "IRMP"
   - "IAIP"
-  - "IBM i"
+
 available_for:
   - "mentoring"
   - "speaking"
   - "consulting"
   - "open-source"
   - "collaboration"
+
 projects:
+  - name: "Legacy Control Lab"
+    url: "https://github.com/jtflack-grc/legacy-control-lab"
+    description: "An interactive IBM i evidence and assurance environment that turns legacy-platform security, audit evidence, privileged access, journaling, and control testing into hands-on GRC exercises. Built to show how modern evidence engineering and assurance practices can be applied to systems that rarely appear in cloud-native GRC examples."
+
+  - name: "Power & IBM i Security Sort"
+    url: "https://jtflack-grc.github.io/power-and-ibm-i-security-sort/"
+    description: "A browser-based IBM i security and evidence triage experience combining platform security context, PTF and PSIRT information, interactive 5250-style workflows, and SQL evidence engineering. Designed to make legacy infrastructure security findings understandable and actionable for GRC and assurance practitioners."
+
+  - name: "GRC Engineering Pipeline"
+    url: "https://github.com/jtflack-grc/grc-engineering-pipeline"
+    description: "An end-to-end control evidence engineering pipeline covering control definitions, OSCAL artifacts, automated validation, regression blocking, signed evidence bundles, and immutable evidence storage. Built during the GRC Engineering Club six-week challenge and awarded second place."
+
+  - name: "Inquisition"
+    url: "https://github.com/jtflack-grc/inquisition"
+    description: "A decision-oriented GRC application for consolidating and interrogating risk information from multiple sources. Uses a risk 'nutrition label' approach to expose assumptions, provenance, materiality, and evidence quality rather than presenting risk outputs as unquestioned conclusions."
+
   - name: "Impact!"
     url: "https://jtflack-grc.github.io/impact/"
-    description: "IMPACT! — Cyber Risk Financial Impact Model A browser-based risk modeling artifact that connects cyber risk scenarios to executive finance concepts such as EBITDA impact, recovery cost, debt service coverage, and operational loss exposure. Built to help move GRC conversations beyond heatmaps and into decision-grade analysis."
-  - name: "Inheritance"
-    url: "https://jtflack-grc.github.io/inheritance/"
-    description: "Inheritance is an interactive governance and risk simulation platform designed to explore complex decision-making in animal welfare systems. The simulator allows users to test how funding choices, policy interventions, enforcement strategies, and resource constraints influence real-world outcomes for non-human animals"
+    description: "A browser-based cyber risk financial impact model connecting cyber scenarios to executive finance concepts such as EBITDA impact, recovery cost, debt service coverage, and operational loss exposure. Built to move risk conversations beyond heatmaps and toward decision-grade financial analysis."
+
   - name: "Decision-Ready Risk Canvas"
     url: "https://jtflack-grc.github.io/decision-ready/"
-    description: "The project was created as a companion artifact to the article “Audit-Ready Is Not Decision-Ready,” and is intended to demonstrate how governance work can move from risk display toward decision support. It is especially oriented toward legacy systems, IBM i / midrange environments, operational resilience, audit evidence, modernization risk, and cyber risk quantification practices."
+    description: "A companion artifact to 'Audit-Ready Is Not Decision-Ready' that demonstrates how governance work can move from risk display toward decision support. It focuses on legacy systems, operational resilience, audit evidence, modernization risk, and cyber risk quantification."
+
+  - name: "Inheritance"
+    url: "https://jtflack-grc.github.io/inheritance/"
+    description: "An interactive governance and risk simulation exploring complex decision-making in animal welfare systems. Users can test how funding choices, policy interventions, enforcement strategies, and resource constraints alter real-world outcomes."
+
 ---
 
 ## About Me
 
-I'm at a strange intersection of legacy infrastructure, governance, risk, and practical assurance. My background is rooted in IBM i, AIX, infrastructure operations, change governance, disaster recovery, audit response, and regulated healthcare environments. Over time, that operational work has evolved into a broader focus on how organizations govern the systems they depend on but often do not fully understand.
+I'm at a strange intersection of legacy infrastructure, governance, risk, and practical assurance. My background is rooted in IBM i, AIX, infrastructure operations, change governance, disaster recovery, audit response, security engineering, and regulated healthcare environments. Over time, that operational work has evolved into a broader focus on how organizations govern the systems they depend on but often do not fully understand.
 
-My GRC interests center on the gap between frameworks and operating reality. I’m especially interested in legacy systems governance, cyber risk quantification, AI governance, cloud risk, modernization debt, and the practical evidence organizations need to make better decisions. I tend to approach GRC less as a documentation exercise and more as a way to create visibility, accountability, and decision support.
+My GRC interests center on the gap between frameworks and operating reality. I’m especially interested in legacy systems governance, control evidence engineering, cyber risk quantification, AI governance, cloud risk, modernization debt, third-party risk, and the practical evidence organizations need to make better decisions.
 
-A lot of my current work is artifact-driven. I build and write around tools, models, explainers, and practical examples that connect control language to real-world systems. That includes cyber risk financial modeling, IBM i governance research, AI assurance concepts, and writing through the “i on GRC” series.
+I tend to approach GRC less as a documentation exercise and more as a way to create visibility, accountability, and decision support.
 
-My big thing is helping make invisible infrastructure visible enough to govern. Whether the topic is legacy platforms, AI systems, cloud services, or risk quantification, I’m most interested in the point where governance stops being abstract and starts helping people understand what they own, what they depend on, and what decisions they need to make.
+A lot of my current work is artifact-driven. I build tools, simulations, labs, evidence pipelines, models, and explainers that connect control language to real-world systems.
+
+Projects such as **Legacy Control Lab** and **Power & IBM i Security Sort** focus specifically on bringing modern assurance and evidence-engineering concepts into IBM i and other legacy environments. **Impact!** explores the connection between cyber risk and financial outcomes. **Inquisition** focuses on risk-source provenance and materiality. My **GRC Engineering Pipeline** explores automated control validation, OSCAL, signed evidence, and immutable evidence storage.
+
+My big thing is helping make invisible infrastructure visible enough to govern.
+
+Whether the subject is IBM i, AI systems, cloud services, third parties, or quantitative risk, I’m most interested in the point where governance stops being abstract and starts helping people understand what they own, what they depend on, what the evidence actually says, and what decisions they need to make.
 
 ## Experience Highlights
 
-- IBM i, AIX, and infrastructure operations experience in regulated healthcare environments
-- Practical experience with change governance, audit response, disaster recovery planning, and operational control evidence
-- Focused on legacy systems governance, modernization risk, and accountability gaps in critical business systems
-- Builder of GRC artifacts that connect risk analysis to operational and financial decision-making
-- Active writer on governance, risk, legacy infrastructure, AI governance, and decision-grade assurance
-- Experience translating technical platform constraints into governance, risk, and executive-facing language
-- Interested in FAIR-style cyber risk quantification, AI assurance, cloud governance, and practical control mapping
-- Board/member involvement in cybersecurity and cloud security professional communities
+- More than two decades of enterprise systems and infrastructure experience spanning IBM i, AIX, UNIX, Linux, security, and regulated environments
+- Practical experience with change governance, audit response, disaster recovery, privileged access, operational controls, and control evidence
+- Deep focus on IBM i and legacy systems governance, including modernization risk and accountability gaps in critical business platforms
+- Builder of hands-on GRC labs and evidence-engineering artifacts rather than framework-only demonstrations
+- Experience translating technical platform constraints and operational realities into governance, risk, audit, and executive-facing language
+- Work spanning cyber risk quantification, financial impact modeling, control assurance, vulnerability governance, third-party risk, cloud security, and AI governance
+- Active writer on governance, legacy infrastructure, AI assurance, modernization risk, and decision-grade GRC
+- Contributor to open-source and community GRC engineering projects
+- Leadership and volunteer involvement across cybersecurity, cloud security, GRC, and professional mentoring communities
+
+## Selected Work
+
+### Legacy Control Lab
+
+**Legacy Control Lab (LCL)** is an interactive IBM i evidence runtime built around a deliberately underrepresented problem in GRC engineering: applying modern assurance practices to legacy and on-premises systems.
+
+The lab uses IBM i-style workflows, 5250 interfaces, audit-journal evidence, user-profile analysis, privileged-access scenarios, and guided missions to demonstrate how control objectives translate into actual platform evidence.
+
+Repository:  
+https://github.com/jtflack-grc/legacy-control-lab
+
+### Power & IBM i Security Sort
+
+**Power & IBM i Security Sort** extends that work into security triage and evidence engineering. It combines IBM i platform context, PTF and PSIRT data, interactive terminal workflows, and SQL-based evidence techniques to help practitioners move from raw technical findings toward assurance decisions.
+
+Project:  
+https://jtflack-grc.github.io/power-and-ibm-i-security-sort/
+
+### GRC Engineering Pipeline
+
+Built as part of the GRC Engineering Club six-week challenge, the pipeline demonstrates an end-to-end evidence lifecycle using control definitions, OSCAL, automated checks, regression blocking, signed evidence bundles, and immutable storage.
+
+The project received **second place in the GRC Engineering Club six-week challenge**.
+
+Repository:  
+https://github.com/jtflack-grc/grc-engineering-pipeline
+
+### Inquisition
+
+**Inquisition** explores what happens when risk information from multiple sources is treated as evidence to be interrogated rather than as authoritative output.
+
+Its "risk nutrition label" approach surfaces provenance, assumptions, materiality, confidence, and evidence quality so decision-makers can understand what sits underneath a risk conclusion.
+
+Repository:  
+https://github.com/jtflack-grc/inquisition
+
+### Impact!
+
+**Impact!** connects cyber risk scenarios to financial measures including EBITDA impact, recovery cost, operational loss, and debt-service implications.
+
+It is designed to help bridge the persistent gap between technical security findings and the financial decisions executives actually have to make.
+
+Project:  
+https://jtflack-grc.github.io/impact/
+
+### Decision-Ready Risk Canvas
+
+The **Decision-Ready Risk Canvas** explores the distinction between being able to satisfy an audit request and actually providing enough information to make a risk decision.
+
+It is particularly oriented toward legacy systems, modernization risk, resilience, technical debt, control evidence, and quantitative risk.
+
+Project:  
+https://jtflack-grc.github.io/decision-ready/
+
+### Inheritance
+
+**Inheritance** is an interactive governance simulation exploring how policy, funding, enforcement, resource allocation, and uncertainty interact in complex animal-welfare systems.
+
+It serves as a broader demonstration of my interest in using interactive artifacts to make governance tradeoffs visible rather than leaving them buried in static documentation.
+
+Project:  
+https://jtflack-grc.github.io/inheritance/
+
+## Current Areas of Interest
+
+- Legacy and on-premises GRC engineering
+- IBM i security and assurance
+- Control evidence engineering
+- Auditability and continuous assurance
+- Cyber risk quantification
+- FAIR-style risk analysis
+- AI governance and AI assurance
+- Third-party risk
+- Cloud and hybrid-environment governance
+- Modernization and technology-debt risk
+- Operational resilience
+- Translating technical evidence into executive decisions
 
 ## Get in Touch
 
-LinkedIn DM is the best way to connect. I’m always interested in thoughtful conversations around GRC, legacy systems, IBM i, cyber risk quantification, AI governance, cloud security, auditability, and practical ways to make governance more decision-ready.
+LinkedIn DM is the best way to connect.
+
+I'm especially interested in thoughtful conversations and collaborations around GRC engineering, legacy systems, IBM i, cyber risk quantification, AI governance, cloud security, auditability, control evidence, modernization risk, and practical ways to make governance more decision-ready.

--- a/engineers/jtflack-grc.md
+++ b/engineers/jtflack-grc.md
@@ -4,7 +4,7 @@ github: "jtflack-grc"
 title: "Systems & Security Engineer"
 location: "High Point, NC"
 linkedin: "https://www.linkedin.com/in/john-flack"
-portfolio: "https://jtflack-grc.github.io/portfolio/"
+website: "https://jtflack-grc.github.io/portfolio/"
 
 specializations:
   - "Audit & Assurance"


### PR DESCRIPTION
Updated personal information, specializations, and projects for John Flack. Added new certifications and refined descriptions for clarity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated John Flack’s professional profile, including title, specialties, frameworks, languages, and certifications.
  * Expanded and refreshed the project portfolio with work covering legacy systems, security, GRC engineering, evidence engineering, and decision support.
  * Revised the biography, experience highlights, selected work, areas of interest, and contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->