### PR TITLE
fix: restrict sync-chapters input path

### DIFF
--- a/scripts/sync-chapters.js
+++ b/scripts/sync-chapters.js
@@ -28,6 +28,42 @@ const REGION = {
 // must not mass-delete chapter pages.
 const MIN_LIVE_CHAPTERS = 15;
 
+// The sync-chapters workflow always hands us a file inside /tmp
+// (see .github/workflows/sync-chapters.yml). Treat that as the only
+// approved input location and refuse to read anything outside it.
+const INPUT_DIR = "/tmp";
+
+// Resolve the caller-provided input path against the approved input directory
+// and refuse anything that escapes it. path.resolve + a .json suffix check are
+// not enough on their own: they still permit absolute paths, ../ traversal, and
+// symlinks that point elsewhere. We canonicalize with fs.realpathSync so a
+// symlinked file cannot smuggle us outside the boundary, then verify
+// containment with path.relative before the file is ever read.
+function resolveInputPath(src, inputDir = INPUT_DIR) {
+  // realpath the boundary too: on macOS /tmp is itself a symlink to
+  // /private/tmp, so both sides must be canonicalized to compare.
+  const baseReal = fs.realpathSync(inputDir);
+  const candidate = path.resolve(baseReal, src);
+
+  // Canonicalize the target if it exists so a symlinked file that points
+  // outside the boundary is caught; fall back to the lexical path otherwise.
+  let resolved;
+  try {
+    resolved = fs.realpathSync(candidate);
+  } catch {
+    resolved = candidate;
+  }
+
+  const rel = path.relative(baseReal, resolved);
+  if (rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel)) {
+    throw new Error(`input file must be inside ${inputDir}`);
+  }
+  if (!resolved.endsWith(".json")) {
+    throw new Error("input file must have a .json extension");
+  }
+  return resolved;
+}
+
 function yamlStr(value) {
   const needsQuote =
     value.includes(": ") ||
@@ -75,9 +111,11 @@ function main() {
     process.exit(1);
   }
 
-  const resolvedSrc = path.resolve(src);
-  if (!resolvedSrc.endsWith(".json")) {
-    console.error("Error: input file must have a .json extension");
+  let resolvedSrc;
+  try {
+    resolvedSrc = resolveInputPath(src);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
     process.exit(1);
   }
 
@@ -113,4 +151,8 @@ function main() {
   console.log(`synced ${wrote} chapters, removed ${removed}`);
 }
 
-main();
+if (require.main === module) {
+  main();
+}
+
+module.exports = { resolveInputPath, render, yamlStr };

--- a/scripts/sync-chapters.js
+++ b/scripts/sync-chapters.js
@@ -75,7 +75,13 @@ function main() {
     process.exit(1);
   }
 
-  const data = JSON.parse(fs.readFileSync(src, "utf8"));
+  const resolvedSrc = path.resolve(src);
+  if (!resolvedSrc.endsWith(".json")) {
+    console.error("Error: input file must have a .json extension");
+    process.exit(1);
+  }
+
+  const data = JSON.parse(fs.readFileSync(resolvedSrc, "utf8"));
   const live = data.chapters.filter((c) => c.leaders && c.leaders.length > 0);
   if (live.length < MIN_LIVE_CHAPTERS) {
     console.error(

--- a/tests/sync-chapters.test.js
+++ b/tests/sync-chapters.test.js
@@ -1,0 +1,87 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const { resolveInputPath } = require("../scripts/sync-chapters");
+
+// Each case builds a throwaway input directory so we exercise the containment
+// boundary without touching the real /tmp. resolveInputPath takes the boundary
+// as an argument for exactly this reason.
+function withScratchDir(fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "sync-chapters-"));
+  // Canonicalize so assertions compare against the same path realpath returns
+  // (macOS resolves the tmp symlink to /private/...).
+  const realDir = fs.realpathSync(dir);
+  try {
+    fn(realDir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("resolveInputPath accepts a .json file inside the input directory", () => {
+  withScratchDir((dir) => {
+    fs.writeFileSync(path.join(dir, "chapters.json"), "{}");
+    const resolved = resolveInputPath("chapters.json", dir);
+    assert.equal(resolved, path.join(dir, "chapters.json"));
+  });
+});
+
+test("resolveInputPath accepts an absolute path inside the input directory", () => {
+  withScratchDir((dir) => {
+    const abs = path.join(dir, "chapters.json");
+    fs.writeFileSync(abs, "{}");
+    assert.equal(resolveInputPath(abs, dir), abs);
+  });
+});
+
+test("resolveInputPath rejects ../ traversal out of the input directory", () => {
+  withScratchDir((dir) => {
+    assert.throws(() => resolveInputPath("../escape.json", dir), /inside/);
+  });
+});
+
+test("resolveInputPath rejects an absolute path outside the input directory", () => {
+  withScratchDir((dir) => {
+    assert.throws(() => resolveInputPath("/etc/passwd.json", dir), /inside/);
+  });
+});
+
+test("resolveInputPath rejects a lexical escape that climbs above the directory", () => {
+  withScratchDir((dir) => {
+    assert.throws(
+      () => resolveInputPath("subdir/../../escape.json", dir),
+      /inside/,
+    );
+  });
+});
+
+test("resolveInputPath rejects a symlink inside the dir pointing outside", () => {
+  withScratchDir((dir) => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), "sync-outside-"));
+    const target = path.join(outside, "secret.json");
+    fs.writeFileSync(target, "{}");
+    const link = path.join(dir, "link.json");
+    try {
+      fs.symlinkSync(target, link);
+    } catch {
+      // Some environments disallow symlink creation; nothing to assert there.
+      fs.rmSync(outside, { recursive: true, force: true });
+      return;
+    }
+    try {
+      assert.throws(() => resolveInputPath("link.json", dir), /inside/);
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});
+
+test("resolveInputPath rejects a non-.json file inside the directory", () => {
+  withScratchDir((dir) => {
+    fs.writeFileSync(path.join(dir, "chapters.txt"), "{}");
+    assert.throws(() => resolveInputPath("chapters.txt", dir), /\.json/);
+  });
+});


### PR DESCRIPTION
## Summary

Harden the filesystem input boundary of `scripts/sync-chapters.js`.

The script takes a caller-provided path (`process.argv[2]`) and passes it to `fs.readFileSync()`. This PR ensures that path stays within the intended input directory before it is read.

## Scope / honesty note

I am **not** claiming a demonstrated, externally reachable exploit. The production workflow (`.github/workflows/sync-chapters.yml`) invokes the script with a hardcoded `/tmp/chapters.json`, and the script contains no `child_process`/`exec`/`spawn` — so there is no attacker-controlled input in the current call chain. (The earlier CRITICAL / CWE-78 "shell/subprocess" framing was inaccurate and has been removed.)

This change instead **hardens the script's input contract** so the boundary holds if the input path ever becomes configurable.

## Change

The previous guard was:

```js
const resolvedSrc = path.resolve(src);
if (!resolvedSrc.endsWith(".json")) { /* reject */ }
```

That does **not** prevent traversal — it still permits absolute paths, `../` escapes, and symlinks that resolve outside the intended location; the `.endsWith(".json")` check alone is effectively a no-op for the real argument.

Replaced with a canonical-path containment check (`resolveInputPath`):

- resolve the input against the approved input directory (`/tmp`, where the workflow downloads `chapters.json`);
- canonicalize both the boundary and the target with `fs.realpathSync` so a symlink can't smuggle the read outside;
- reject anything whose resolved path escapes the boundary (`path.relative` → `..` / absolute);
- retain the `.json` extension check.

The production argument `/tmp/chapters.json` continues to work unchanged.

## Tests

Added `tests/sync-chapters.test.js` (runs under the existing `npm test` / `node --test tests/*.test.js`) covering the boundary contract:

- valid `.json` inside the input dir (relative and absolute) → accepted
- `../` traversal → rejected
- absolute path outside the dir → rejected
- lexical escape (`subdir/../../escape.json`) → rejected
- symlink inside the dir pointing outside → rejected
- non-`.json` input → rejected

## Files
- `scripts/sync-chapters.js`
- `tests/sync-chapters.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chapter synchronization when handling absolute or relative input paths.
  * Added validation to require `.json` chapter files within the permitted input directory.
  * Prevented path traversal and symlink-based access to files outside the permitted directory.
  * Improved error reporting when an input path cannot be validated.
* **Tests**
  * Added coverage for valid paths, invalid extensions, traversal attempts, and directory escape scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->