### PR TITLE
fix(seo): give every directory page a unique, click-earning snippet

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
     paths:
       - 'engineers/*.md'
+      # engineers.11tydata.js computes each profile's SEO title/description,
+      # so a change there alters every built profile page.
+      - 'engineers/*.js'
       - 'chapters/**'
       - 'jobs/**'
       - 'site/**'

--- a/engineers/engineers.11tydata.js
+++ b/engineers/engineers.11tydata.js
@@ -1,8 +1,71 @@
+const SITE_NAME = "GRC Engineer Directory";
+const MAX_DESC = 155;
+
+// Meta descriptions are measured after HTML escaping, and "&" costs 5 characters
+// as "&amp;". Specialization names like "Audit & Assurance" are common enough that
+// budgeting against the raw string overshoots the SERP truncation limit.
+function escapedLength(str) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").length;
+}
+
+function article(word) {
+  return /^[aeiou]/i.test(String(word || "")) ? "an" : "a";
+}
+
+function clamp(str) {
+  if (escapedLength(str) <= MAX_DESC) return str;
+  let out = str;
+  while (out.length && escapedLength(out) > MAX_DESC - 1) {
+    out = out.slice(0, out.lastIndexOf(" "));
+  }
+  return `${out}…`;
+}
+
+function buildSeoTitle(data) {
+  if (!data.name) return null;
+  return `${data.name} - ${data.title || "GRC Engineer"} | ${SITE_NAME}`;
+}
+
+function buildSeoDescription(data) {
+  if (!data.name) return null;
+
+  const role = data.title || "GRC engineer";
+  let out = `${data.name} is ${article(role)} ${role}`;
+
+  const add = (clause) => {
+    const next = `${out} ${clause}`;
+    if (escapedLength(next) <= MAX_DESC) out = next;
+  };
+
+  if (data.company) add(`at ${data.company}`);
+  if (data.location) add(`in ${data.location}`);
+  out = `${clamp(out)}.`;
+
+  const specializations = Array.isArray(data.specializations) ? data.specializations : [];
+  if (specializations.length) {
+    add(`Specializes in ${specializations.slice(0, 3).join(", ")}.`);
+  }
+
+  const frameworks = Array.isArray(data.frameworks) ? data.frameworks : [];
+  if (frameworks.length) {
+    add(`Frameworks: ${frameworks.slice(0, 3).join(", ")}.`);
+  }
+
+  return out;
+}
+
 module.exports = {
   layout: "layouts/profile.njk",
   permalink: "engineers/{{ github }}/index.html",
   tags: "engineers",
   eleventyComputed: {
-    eleventyExcludeFromCollections: data => data.page.fileSlug === "_template"
+    eleventyExcludeFromCollections: data => data.page.fileSlug === "_template",
+    isEngineerProfile: () => true,
+    seoTitle: data => buildSeoTitle(data),
+    seoDescription: data => buildSeoDescription(data)
   }
 };

--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -1,10 +1,23 @@
+{%- set pageTitle = seoTitle if seoTitle else (name + " - GRC Engineer Directory" if name else (title or "GRC Engineer Directory")) -%}
+{%- set pageDesc = seoDescription or description or "Find GRC engineers to hire by specialization, framework expertise, and availability." -%}
+{%- set pageUrl = "https://directory.grcengclub.com" + page.url -%}
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ name + " - GRC Engineer Directory" if name else (title or "GRC Engineer Directory") }}</title>
-  <meta name="description" content="{{ description or 'Find GRC engineers to hire by specialization, framework expertise, and availability.' }}">
+  <title>{{ pageTitle }}</title>
+  <meta name="description" content="{{ pageDesc }}">
+  <link rel="canonical" href="{{ pageUrl }}">
+  <meta property="og:type" content="{{ "profile" if isEngineerProfile else "website" }}">
+  <meta property="og:site_name" content="GRC Engineer Directory">
+  <meta property="og:title" content="{{ pageTitle }}">
+  <meta property="og:description" content="{{ pageDesc }}">
+  <meta property="og:url" content="{{ pageUrl }}">
+  {% if isEngineerProfile and github %}<meta property="og:image" content="https://github.com/{{ github }}.png?size=400">{% endif %}
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="{{ pageTitle }}">
+  <meta name="twitter:description" content="{{ pageDesc }}">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@500;600;700;800&display=swap" rel="stylesheet">

--- a/site/_includes/layouts/profile.njk
+++ b/site/_includes/layouts/profile.njk
@@ -9,8 +9,14 @@ layout: layouts/base.njk
   "jobTitle": {{ (title or '') | dump | safe }},
   {% if company %}"worksFor": { "@type": "Organization", "name": {{ company | dump | safe }} },{% endif %}
   {% if location %}"address": { "@type": "PostalAddress", "addressLocality": {{ location | dump | safe }} },{% endif %}
-  "url": "https://grc-engineering-club.github.io/engineers/{{ github }}/",
-  "image": "https://github.com/{{ github }}.png"
+  "url": "https://directory.grcengclub.com/engineers/{{ github }}/",
+  "image": "https://github.com/{{ github }}.png",
+  "memberOf": { "@type": "Organization", "name": "GRC Engineering Club", "url": "https://grcengclub.com" },
+  "sameAs": [
+    "https://github.com/{{ github }}"{% if linkedin %},
+    {{ linkedin | dump | safe }}{% endif %}{% if website %},
+    {{ website | dump | safe }}{% endif %}
+  ]
 }
 </script>
 {% set socialData = {

--- a/site/jobs.njk
+++ b/site/jobs.njk
@@ -1,8 +1,9 @@
 ---
 layout: layouts/base.njk
-title: Open GRC Engineering Roles
 permalink: /jobs/index.html
-description: A GRC Engineering Club community resource for browsing open GRC engineering roles alongside the member directory.
+eleventyComputed:
+  title: "{{ collections.jobs.length }} Open GRC Engineering Jobs | GRC Engineer Directory"
+  description: "Browse {{ collections.jobs.length }} open GRC engineering, IT audit, and compliance roles by framework, specialization, and work mode. A free GRC Engineering Club job board."
 ---
 <section class="jobs-hero">
   <div class="jobs-hero-inner">


### PR DESCRIPTION
## Why

Search Console (2026-08-04 → 08-20) shows `directory.grcengclub.com` taking **1,638 impressions at 1.04% CTR** — 11% of the org's total search impressions, converting at a fifth of what the main site does.

| Page | Impressions | Clicks | CTR | Avg position |
|---|---|---|---|---|
| `/jobs/` | 498 | 3 | 0.60% | 7.5 |
| `/engineers/robertwiley-grc/` | 52 | **0** | 0% | **4.6** |

A profile ranking at position 4.6 with zero clicks is not a ranking problem. The pages rank; the snippets give nobody a reason to click.

## Root causes

**All 70 profiles shipped the identical description.** Profiles never set `description`, so every one fell through to the layout's fallback — "Find GRC engineers to hire by specialization, framework expertise, and availability." Google was seeing 70 near-duplicate snippets.

**The person's job title never reached the page title.** `base.njk` rendered `{{ name }} - GRC Engineer Directory` for every profile, so someone searching a name got a directory label instead of a reason to click.

**Person JSON-LD pointed at the wrong hostname.** `url` was `https://grc-engineering-club.github.io/engineers/{github}/` rather than the custom domain, splitting entity signals across two hostnames.

**The jobs page title was static.** "Open GRC Engineering Roles" — no count, no brand, no freshness signal, for a job board carrying 125 live roles.

**No canonical, OG, or Twitter tags existed anywhere on the subdomain.**

## Changes

- `engineers/engineers.11tydata.js` computes `seoTitle` and `seoDescription` per profile from its own front matter (role, company, location, specializations, frameworks)
- `base.njk` consumes them and gains canonical + OG + Twitter tags
- `profile.njk` Person JSON-LD now points at `directory.grcengclub.com` and gains `sameAs` (GitHub, LinkedIn, website) plus `memberOf` linking each engineer to the GRC Engineering Club org entity
- `jobs.njk` leads with the live count via `collections.jobs`, so it stays accurate at every build
- Deploy workflow now watches `engineers/*.js` — that file became load-bearing in this PR, and without it a change to the SEO logic would silently not ship

Descriptions are budgeted against **HTML-escaped** length: `&` costs 5 characters as `&amp;`, and specializations like "Audit & Assurance" are common enough that budgeting the raw string overshoots SERP truncation.

## Verification against built output

| Check | Result |
|---|---|
| Profiles built | 70 |
| Unique titles | 70/70 |
| Unique descriptions | 70/70 |
| Description length | 105–155 chars, **0 over 160** |
| JSON-LD parse failures | 0 |
| Wrong-hostname leaks | 0 |
| `is a AI…` grammar slips | 0 |
| Home page snippet | unchanged (no regression) |

Sample: `Robert E. Wiley Jr. - GRC Mission Assurance Architect | GRC Engineer Directory`

## Not in this PR

Adding GA4 to the subdomain — it carries these impressions but has never had an analytics tag, so none of the traffic appears in GA4. That change is on `seo/directory-ga4` and is held back deliberately: it changes what the site collects from visitors, which is a separate decision from snippet quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SEO-optimized titles and descriptions for engineer profile pages.
  * Added canonical, Open Graph, and Twitter metadata across site pages.
  * Enhanced profile structured data with organization, GitHub, LinkedIn, and website links.
  * Updated jobs page metadata to reflect the current number of listings.

* **Bug Fixes**
  * Deployment workflows now rebuild the site when engineer-related JavaScript data changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->