### PR TITLE
feat(analytics): add GA4 to the directory subdomain

### DIFF
--- a/site/_includes/layouts/base.njk
+++ b/site/_includes/layouts/base.njk
@@ -22,6 +22,17 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Plus+Jakarta+Sans:wght@500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/site/assets/css/style.css">
+  <!-- GA4: same property as grcengclub.com so directory traffic is no longer
+       invisible in analytics. The /seo report tooling excludes this hostname
+       from marketing-site metrics and reports it separately, so adding this
+       does not distort grcengclub.com trend lines. -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K0NXL2H9M8"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-K0NXL2H9M8');
+  </script>
   <script>
     (function() {
       var saved = localStorage.getItem('theme');


### PR DESCRIPTION
## Why

`directory.grcengclub.com` carries **~1,638 search impressions per 17-day window** but has never had an analytics tag. None of that traffic appears in GA4. Search Console sees it only because the property is a `sc-domain:` Domain property covering all subdomains — so we can see it rank, but not what people do once they arrive.

## Approach

Uses the **same** measurement ID as grcengclub.com (`G-K0NXL2H9M8`) rather than a separate property, so cross-domain journeys stay visible in one place.

The obvious risk with that choice is contaminating the marketing site's trend lines — a new traffic source appearing as if it were growth, right as GSC period-over-period comparisons come online around 9/5. That is handled on the reporting side rather than by splitting properties: the `/seo` tooling now excludes `directory.grcengclub.com` from marketing-site metrics and reports it as its own section.

So this PR adds collection; the reporting change keeps grcengclub.com's numbers comparable across the boundary.

## Verification

Built locally; `gtag` renders on home, jobs, and profile pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)