### PR TITLE
fix(deps): patch three high-severity build-time DoS advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -384,9 +384,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -964,9 +964,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -1034,9 +1034,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.27.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
-      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
+      "version": "10.29.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.29.0.tgz",
+      "integrity": "sha512-pCVOhs6FLAR8su3ItJ07diN26t6W5dHQRnmTMy8HPyTFuv1+oSCVJIGp5pGjfQyOZfh50KswvKtMTp6p4JEIdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

`npm audit` reports **three** high-severity vulnerabilities — Dependabot surfaced only two of them. All three are transitive dev dependencies of `@11ty/eleventy`, and all three are resource-exhaustion DoS:

| Package | Installed | Patched | Advisory |
|---|---|---|---|
| `js-yaml` (via gray-matter) | 3.15.0 | 3.15.1 | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU in `!!omap` |
| `js-yaml` (via eleventy) | 4.3.0 | 4.3.1 | same advisory, 4.x branch |
| `brace-expansion` | 1.1.16 | 1.1.18 | unbounded expansion → OOM crash |
| `liquidjs` | 10.27.0 | 10.29.0 | [GHSA-g357-x5c3-c72p](https://github.com/advisories/GHSA-g357-x5c3-c72p) — `pop` bypasses `memoryLimit` |

## Actual exposure

Narrower than "high" implies, but not zero.

This repo accepts **community-submitted engineer profiles by PR**, and their YAML front matter reaches `js-yaml` through `gray-matter` during `npm run build`. A crafted `!!omap` in a merged profile could hang the Pages build.

Two things bound the risk:

- The PR-time validation gate (`validate-submission.yml`) uses the **`yq` Go binary**, not js-yaml — so the untrusted-input checkpoint is not itself exposed. An attacker needs their profile *merged* first.
- Nothing here ships to visitors. The deployed artifact is static HTML; these are build-time dependencies only. This is a CI availability issue, not RCE and not a data-exposure issue.

## Change

Lockfile only — all four bumps are semver-compatible with the existing ranges (`^4.1.0` already permits 4.3.1, `^3.13.1` permits 3.15.1), so `package.json` is untouched.

## Verification

`liquidjs` is one of eleventy's template engines, so "patch bump" is not sufficient assurance on its own. I built the complete site against both the old and the new lockfile and compared a SHA-256 over all **344** output files:

```
old deps: 230f9bb7e71f364dbd07fbea1072aa576d5e26e4198fff7adaa2ba1ca1411661
new deps: 230f9bb7e71f364dbd07fbea1072aa576d5e26e4198fff7adaa2ba1ca1411661
```

Byte-for-byte identical. `npm audit` now reports **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)